### PR TITLE
Add skip-mas entity batch path to News Monitor MAS

### DIFF
--- a/News_Monitor_MAS/README.md
+++ b/News_Monitor_MAS/README.md
@@ -1,8 +1,39 @@
 # Client News Monitor
 
-Retrieval-only news monitor for ~3,000 US small/mid companies over a configurable Bigdata timestamp window. Scores abnormal news volume (MAS) across four fixed monitor topics — no LLM labeling, no MCP.
+Retrieval-only news monitor for ~3,000 US small/mid companies over a configurable Bigdata timestamp window. Two modes: **topic + MAS** (default production path) and **`--skip-mas`** (entity-only smart batch over the full universe). No LLM labeling, no MCP.
 
-Uses [Bigdata.com](https://bigdata.com) smart search and [bigdata-smart-batching](https://docs.bigdata.com/use-cases/search-service/smart-batching).
+Uses [Bigdata.com](https://bigdata.com) smart search and [bigdata-smart-batching](https://docs.bigdata.com/use-cases/search-service/smart-batching). Default document category is **`news`** (override with `--category-profile news_premium`).
+
+## Skip-MAS entity batch (full universe)
+
+`--skip-mas` skips themes and MAS scoring. It hands the full company list to `plan_search` (`text=None`); the library densifies baskets and packs zero-volume names into **`very_low`** groups. Then `execute_search` runs with an explicit **`--chunk-percentage`**.
+
+```bash
+# Full ~3k universe, retrieve 50% of the planned chunk budget
+uv run client-news-monitor \
+  --skip-mas \
+  --chunk-percentage 0.5 \
+  --output-dir runs/skip_mas_3k_50pct
+```
+
+### How planning vs retrieval works
+
+1. **`plan_search`** estimates co-mention volumes (day-granular dates) and builds baskets (volume buckets + dense `very_low` for zeros).
+2. We **patch** each basket’s timestamps to the exact monitor ISO window (often 15 minutes).
+3. **`--chunk-percentage`** sets the retrieval **cap**:  
+   `target ≈ chunk_upper_bound_estimate × chunk_percentage`  
+   Example: expected 76,441 × 0.5 → target ≈ **38,220** max chunks to *request*.
+4. The API only returns what exists in the window. Flattened output is much smaller — e.g. **758 rows / 500 primary** in a quiet 15‑min `news` run.
+
+| Metric | Meaning |
+|--------|---------|
+| Plan expected / target | Upper bound on chunks we are willing to request |
+| `chunk_rows` | Rows in `retrieval_chunks.jsonl` (chunk × matched company) |
+| `primary_stories` | Unique headlines after within-run syndication dedup |
+
+**50% does not mean “retrieve half the universe’s news.”** It means “use half of the planner’s expected-chunk budget as `max_chunks`.” Empty windows and short windows under-fill that budget.
+
+Logs spell this out: `chunk_percentage=50% (expected=4,765 → target≈2,382)`.
 
 ## Architecture
 
@@ -85,11 +116,18 @@ uv run client-news-monitor \
   --chunk-percentage 0.5 \
   --output-dir runs/client_poc
 
-# Broader news category (more recall, more noise)
-uv run client-news-monitor --category-profile news --limit-entities 50
+# Narrower premium category
+uv run client-news-monitor --category-profile news_premium --limit-entities 50
 
 # Compare text / topic / text+topic (~3× retrieval cost)
 uv run client-news-monitor ... --compare-modes
+
+# Skip MAS: entity-only smart batch over all names (library densifies zero-volume)
+uv run client-news-monitor \
+  --skip-mas \
+  --chunk-percentage 0.5 \
+  --limit-entities 50 \
+  --output-dir runs/skip_mas_50pct
 ```
 
 ## What it does
@@ -101,7 +139,7 @@ For each of **4 monitor topics** (`earnings`, `contracts`, `leadership`, `regula
 3. **MAS scoring** — Media Attention Score vs a cached 30-day baseline (same query spec)
 4. **Syndication dedup** — headline-hash collapse within the run
 
-**Document category:** controlled by `--category-profile` (default `news_premium`). Use `news` for broader wire coverage at the cost of more noise; `news_premium` excludes SEC filings and transcripts.
+**Document category:** controlled by `--category-profile` (default `news`). Use `news_premium` for narrower premium coverage; `news` includes broader wire coverage at the cost of more noise.
 
 ## MAS scoring
 
@@ -169,9 +207,10 @@ Curated topic filters from `taxonomy.csv` (`TOPIC=business`). Rules in `src/clie
 | `--window-end` | now (UTC) | Window end ISO timestamp |
 | `--window-minutes` | `15` | Window length in minutes |
 | `--search-mode` | `text+topic` | `text`, `topic`, `text+topic`, or `entity_only` |
-| `--category-profile` | `news_premium` | `news_premium` or `news` |
+| `--skip-mas` | off | Entity-only smart batch over all companies; no themes/MAS |
+| `--category-profile` | `news` | `news` or `news_premium` |
 | `--compare-modes` | off | Run all three search modes |
-| `--chunk-percentage` | `0.5` | Proportional chunk sampling per basket |
+| `--chunk-percentage` | `0.5` | Fraction of plan expected chunks to retrieve (0–1; **50%** default) |
 | `--limit-entities` | `0` (all) | Limit to first N companies |
 | `--max-chunks-per-basket` | none | Hard cap on `max_chunks` |
 | `--seen-headlines-db` | none | Optional SQLite for cross-run headline dedup |
@@ -188,6 +227,12 @@ Curated topic filters from `taxonomy.csv` (`TOPIC=business`). Rules in `src/clie
 | `entity_only` | omitted | omitted | `ALL` |
 
 `entity_only` runs **once per search mode** with `monitor_topic=entity_wide` — all news about the entity in the window, not scoped to the four monitor topics. See [Targeted backfill](#targeted-backfill-recommended-not-automated) below.
+
+### Skip MAS (entity-only smart batch)
+
+`--skip-mas` turns off themes and MAS scoring. It calls `bigdata_smart_batching.plan_search` on the full universe (`text=None`) so the library densifies baskets and packs zero-volume names into `very_low` groups, then `execute_search` with **`--chunk-percentage`** as the retrieval budget.
+
+Example: `--chunk-percentage 0.5` means retrieve **50%** of the plan’s `chunk_upper_bound_estimate`. Basket timestamps are patched to the exact monitor ISO window after planning.
 
 ### Targeted backfill (recommended, not automated)
 

--- a/News_Monitor_MAS/src/client_monitor/cli.py
+++ b/News_Monitor_MAS/src/client_monitor/cli.py
@@ -65,20 +65,32 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Run text, topic, and text+topic sequentially",
     )
     parser.add_argument(
+        "--skip-mas",
+        action="store_true",
+        help=(
+            "Skip themes and MAS; run entity-only smart batching over all companies "
+            "(library plan_search densifies including zero-volume names)"
+        ),
+    )
+    parser.add_argument(
         "--category-profile",
         type=str,
         default=DEFAULT_CATEGORY_PROFILE,
         choices=["news_premium", "news"],
         help=(
-            "Bigdata document category filter (default: news_premium; "
-            "news includes broader wire coverage, more noise)"
+            "Bigdata document category filter (default: news; "
+            "news_premium is narrower premium coverage)"
         ),
     )
     parser.add_argument(
         "--chunk-percentage",
         type=float,
         default=0.5,
-        help="Proportional chunk sampling per basket (default: 0.5)",
+        help=(
+            "Fraction of the smart-batching plan's expected chunks to retrieve "
+            "(0.0–1.0). Default 0.5 = 50%%. With --skip-mas this is the main "
+            "retrieval budget control."
+        ),
     )
     parser.add_argument(
         "--limit-entities",
@@ -131,32 +143,51 @@ def main(argv: list[str] | None = None) -> int:
     load_environment()
     output_dir = args.output_dir if args.output_dir is not None else default_output_dir()
 
-    config = build_config(
-        universe_path=args.universe,
-        taxonomy_path=args.taxonomy,
-        output_dir=output_dir,
-        window_end=args.window_end,
-        window_minutes=args.window_minutes,
-        search_mode=args.search_mode,
-        compare_modes=args.compare_modes,
-        category_profile=args.category_profile,
-        chunk_percentage=args.chunk_percentage,
-        limit_entities=args.limit_entities,
-        max_chunks_per_basket=args.max_chunks_per_basket,
-        seen_headlines_db=args.seen_headlines_db,
-        force_baseline_refresh=args.force_baseline_refresh,
-        requests_per_minute=args.requests_per_minute,
-    )
+    try:
+        config = build_config(
+            universe_path=args.universe,
+            taxonomy_path=args.taxonomy,
+            output_dir=output_dir,
+            window_end=args.window_end,
+            window_minutes=args.window_minutes,
+            search_mode=args.search_mode,
+            compare_modes=args.compare_modes,
+            category_profile=args.category_profile,
+            chunk_percentage=args.chunk_percentage,
+            limit_entities=args.limit_entities,
+            max_chunks_per_basket=args.max_chunks_per_basket,
+            seen_headlines_db=args.seen_headlines_db,
+            force_baseline_refresh=args.force_baseline_refresh,
+            requests_per_minute=args.requests_per_minute,
+            skip_mas=args.skip_mas,
+        )
+    except ValueError as exc:
+        raise SystemExit(str(exc)) from exc
 
     logger.info("Output directory: %s", config.output_dir)
-    summary = run_monitor(config)
     logger.info(
-        "Done — %d chunk rows, %d alerts, %d with stories (est. cost $%.4f)",
-        summary["retrieval"]["chunk_rows"],
-        summary["mas"]["alert_count"],
-        summary["mas"]["alerts_with_stories_count"],
-        summary["estimated_cost_usd"],
+        "chunk_percentage=%.0f%% (%s, category=%s)",
+        config.chunk_percentage * 100.0,
+        "skip-mas entity batch" if config.skip_mas else "topic/MAS pipeline",
+        config.category_profile,
     )
+    summary = run_monitor(config)
+    if config.skip_mas:
+        logger.info(
+            "Done — %d chunk rows, %d primary stories, chunk_percentage=%.0f%%, est. cost $%.4f",
+            summary["retrieval"]["chunk_rows"],
+            summary["retrieval"]["primary_stories"],
+            config.chunk_percentage * 100.0,
+            summary["estimated_cost_usd"],
+        )
+    else:
+        logger.info(
+            "Done — %d chunk rows, %d alerts, %d with stories (est. cost $%.4f)",
+            summary["retrieval"]["chunk_rows"],
+            summary["mas"]["alert_count"],
+            summary["mas"]["alerts_with_stories_count"],
+            summary["estimated_cost_usd"],
+        )
     return 0
 
 

--- a/News_Monitor_MAS/src/client_monitor/config.py
+++ b/News_Monitor_MAS/src/client_monitor/config.py
@@ -19,8 +19,8 @@ SEARCH_CATEGORIES: dict[str, dict[str, Any]] = {
     "news": NEWS_CATEGORY,
 }
 
-DEFAULT_SEARCH_CATEGORY: dict[str, Any] = NEWS_PREMIUM_CATEGORY
-DEFAULT_CATEGORY_PROFILE = "news_premium"
+DEFAULT_SEARCH_CATEGORY: dict[str, Any] = NEWS_CATEGORY
+DEFAULT_CATEGORY_PROFILE = "news"
 
 
 def resolve_search_category(profile: str) -> tuple[str, dict[str, Any]]:

--- a/News_Monitor_MAS/src/client_monitor/digest.py
+++ b/News_Monitor_MAS/src/client_monitor/digest.py
@@ -197,19 +197,40 @@ def build_run_summary(
     alerts_with_stories: list[dict[str, Any]] | None = None,
     timings: dict[str, float],
     mode_stats: dict[str, Any] | None = None,
+    skip_mas: bool = False,
 ) -> dict[str, Any]:
     """Build top-level run summary JSON."""
     primary_rows = [row for row in chunk_rows if row.get("is_primary_story", True)]
     syndicated_rows = len(chunk_rows) - len(primary_rows)
-    alerts = _compute_alerts(chunk_rows, mas_rows)
-    if alerts_with_stories is None:
-        alerts_with_stories = build_alerts_with_stories(
-            chunk_rows=chunk_rows,
-            mas_rows=mas_rows,
-        )
-    alert_keys_with_story = {
-        (str(row["entity_id"]), str(row["monitor_topic"])) for row in alerts_with_stories
-    }
+
+    if skip_mas:
+        alerts: list[dict[str, Any]] = []
+        alerts_with_stories = alerts_with_stories or []
+        mas_block: dict[str, Any] = {
+            "skipped": True,
+            "scored_pairs": 0,
+            "alert_count": 0,
+            "alerts_with_stories_count": 0,
+            "story_row_count": 0,
+            "primary_story_count": len(primary_rows),
+        }
+    else:
+        alerts = _compute_alerts(chunk_rows, mas_rows)
+        if alerts_with_stories is None:
+            alerts_with_stories = build_alerts_with_stories(
+                chunk_rows=chunk_rows,
+                mas_rows=mas_rows,
+            )
+        alert_keys_with_story = {
+            (str(row["entity_id"]), str(row["monitor_topic"])) for row in alerts_with_stories
+        }
+        mas_block = {
+            "skipped": False,
+            "scored_pairs": len(mas_rows),
+            "alert_count": len(alerts),
+            "alerts_with_stories_count": len(alert_keys_with_story),
+            "story_row_count": len(alerts_with_stories),
+        }
 
     estimated_chunks = len(chunk_rows)
     estimated_cost_usd = (estimated_chunks / 10.0) * 0.015
@@ -222,17 +243,13 @@ def build_run_summary(
             "chunk_rows": len(chunk_rows),
             "primary_stories": len(primary_rows),
             "syndicated_rows": syndicated_rows,
+            "chunk_percentage": config.get("chunk_percentage"),
         },
         "syndication_stats": {
             "primary_stories": len(primary_rows),
             "syndicated_rows": syndicated_rows,
         },
-        "mas": {
-            "scored_pairs": len(mas_rows),
-            "alert_count": len(alerts),
-            "alerts_with_stories_count": len(alert_keys_with_story),
-            "story_row_count": len(alerts_with_stories),
-        },
+        "mas": mas_block,
         "alerts": alerts[:100],
         "estimated_cost_usd": round(estimated_cost_usd, 4),
     }

--- a/News_Monitor_MAS/src/client_monitor/pipeline.py
+++ b/News_Monitor_MAS/src/client_monitor/pipeline.py
@@ -30,6 +30,7 @@ from src.client_monitor.retrieval import (
     dedupe_rows_by_document,
     flatten_documents,
     plan_entity_ids,
+    plan_entity_only_search,
     run_plan_search,
 )
 from src.client_monitor.taxonomy import build_taxonomy_index, build_topic_filter, load_taxonomy
@@ -60,6 +61,7 @@ class MonitorConfig:
     seen_headlines_db: Path | None
     force_baseline_refresh: bool
     requests_per_minute: int
+    skip_mas: bool = False
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -78,6 +80,7 @@ class MonitorConfig:
             "seen_headlines_db": str(self.seen_headlines_db) if self.seen_headlines_db else None,
             "force_baseline_refresh": self.force_baseline_refresh,
             "requests_per_minute": self.requests_per_minute,
+            "skip_mas": self.skip_mas,
         }
 
 
@@ -198,16 +201,70 @@ def run_topic_mode(
     return chunk_rows, mas_rows, topic_stats
 
 
+def run_skip_mas_entity_batch(
+    *,
+    config: MonitorConfig,
+    entity_ids: list[str],
+    id_to_name: dict[str, str],
+    seen_store: SeenHeadlineStore | None,
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    """Entity-only smart batch over all companies — no themes, no MAS scoring."""
+    start = time.perf_counter()
+    spec = build_entity_wide_spec(window=config.window, category=config.search_category)
+    plan = plan_entity_only_search(
+        entity_ids,
+        window=config.window,
+        category=config.search_category,
+        requests_per_minute=config.requests_per_minute,
+    )
+    expected = int(plan.get("chunk_upper_bound_estimate") or 0)
+    target = int(expected * config.chunk_percentage)
+    basket_count = len(plan.get("baskets") or [])
+    logger.info(
+        "skip-mas entity batch: %d entities, %d baskets, chunk_percentage=%.0f%% "
+        "(expected=%s → target≈%s)",
+        len(entity_ids),
+        basket_count,
+        config.chunk_percentage * 100.0,
+        f"{expected:,}",
+        f"{target:,}",
+    )
+    save_search_plan(plan, config.output_dir / "plans" / "entity_wide_skip_mas.json")
+
+    plan_entities = plan_entity_ids(plan)
+    documents = run_plan_search(
+        plan,
+        chunk_percentage=config.chunk_percentage,
+        requests_per_minute=config.requests_per_minute,
+    )
+    chunk_rows = flatten_documents(
+        documents,
+        spec=spec,
+        plan_entity_ids=plan_entities,
+        id_to_name=id_to_name,
+    )
+    chunk_rows = mark_syndication(chunk_rows)
+    if seen_store is not None:
+        chunk_rows = seen_store.mark_cross_run(chunk_rows)
+
+    stats = {
+        "entities": len(entity_ids),
+        "baskets": basket_count,
+        "expected_chunks": expected,
+        "chunk_percentage": config.chunk_percentage,
+        "target_chunks": target,
+        "retrieved_rows": len(chunk_rows),
+        "elapsed_seconds": round(time.perf_counter() - start, 2),
+    }
+    return chunk_rows, stats
+
+
 def run_monitor(config: MonitorConfig) -> dict[str, Any]:
     """Execute the full client monitor pipeline."""
     config.output_dir.mkdir(parents=True, exist_ok=True)
     write_json(config.output_dir / "config.json", config.to_dict())
 
     entity_ids, id_to_name = _load_entity_universe(config)
-    taxonomy = load_taxonomy(config.taxonomy_path)
-    taxonomy_index = build_taxonomy_index(taxonomy)
-
-    baseline_store = BaselineStore(config.output_dir / "mas_baselines.db")
     seen_store = (
         SeenHeadlineStore(config.seen_headlines_db)
         if config.seen_headlines_db is not None
@@ -219,26 +276,41 @@ def run_monitor(config: MonitorConfig) -> dict[str, Any]:
     mode_stats: dict[str, Any] = {}
     timings: dict[str, float] = {}
 
-    for search_mode in config.search_modes:
-        mode_start = time.perf_counter()
-        chunk_rows, mas_rows, topic_stats = run_topic_mode(
+    if config.skip_mas:
+        chunk_rows, batch_stats = run_skip_mas_entity_batch(
             config=config,
-            search_mode=search_mode,
             entity_ids=entity_ids,
             id_to_name=id_to_name,
-            taxonomy_index=taxonomy_index,
-            baseline_store=baseline_store,
             seen_store=seen_store,
         )
-        all_chunk_rows.extend(chunk_rows)
-        all_mas_rows.extend(mas_rows)
-        mode_stats[search_mode.value] = {
-            "topic_stats": topic_stats,
-            "chunk_rows": len(chunk_rows),
-            "mas_rows": len(mas_rows),
-            "elapsed_seconds": round(time.perf_counter() - mode_start, 2),
-        }
-        timings[f"mode_{search_mode.value}"] = round(time.perf_counter() - mode_start, 2)
+        all_chunk_rows = chunk_rows
+        mode_stats["entity_only_skip_mas"] = batch_stats
+        timings["skip_mas_entity_batch"] = batch_stats["elapsed_seconds"]
+    else:
+        taxonomy = load_taxonomy(config.taxonomy_path)
+        taxonomy_index = build_taxonomy_index(taxonomy)
+        baseline_store = BaselineStore(config.output_dir / "mas_baselines.db")
+
+        for search_mode in config.search_modes:
+            mode_start = time.perf_counter()
+            chunk_rows, mas_rows, topic_stats = run_topic_mode(
+                config=config,
+                search_mode=search_mode,
+                entity_ids=entity_ids,
+                id_to_name=id_to_name,
+                taxonomy_index=taxonomy_index,
+                baseline_store=baseline_store,
+                seen_store=seen_store,
+            )
+            all_chunk_rows.extend(chunk_rows)
+            all_mas_rows.extend(mas_rows)
+            mode_stats[search_mode.value] = {
+                "topic_stats": topic_stats,
+                "chunk_rows": len(chunk_rows),
+                "mas_rows": len(mas_rows),
+                "elapsed_seconds": round(time.perf_counter() - mode_start, 2),
+            }
+            timings[f"mode_{search_mode.value}"] = round(time.perf_counter() - mode_start, 2)
 
     all_chunk_rows = dedupe_rows_by_document(all_chunk_rows)
 
@@ -252,9 +324,13 @@ def run_monitor(config: MonitorConfig) -> dict[str, Any]:
     mas_path = config.output_dir / "mas_scores.csv"
     mas_df.to_csv(mas_path, index=False)
 
-    alerts_with_stories = build_alerts_with_stories(
-        chunk_rows=all_chunk_rows,
-        mas_rows=all_mas_rows,
+    alerts_with_stories = (
+        []
+        if config.skip_mas
+        else build_alerts_with_stories(
+            chunk_rows=all_chunk_rows,
+            mas_rows=all_mas_rows,
+        )
     )
     write_alerts_with_stories_csv(
         config.output_dir / "alerts_with_stories.csv",
@@ -267,7 +343,8 @@ def run_monitor(config: MonitorConfig) -> dict[str, Any]:
         mas_rows=all_mas_rows,
         alerts_with_stories=alerts_with_stories,
         timings=timings,
-        mode_stats=mode_stats if len(config.search_modes) > 1 else None,
+        mode_stats=mode_stats if (config.skip_mas or len(config.search_modes) > 1) else None,
+        skip_mas=config.skip_mas,
     )
     write_json(config.output_dir / "run_summary.json", summary)
     return summary
@@ -289,11 +366,17 @@ def build_config(
     seen_headlines_db: Path | None,
     force_baseline_refresh: bool,
     requests_per_minute: int,
+    skip_mas: bool = False,
 ) -> MonitorConfig:
     """Build ``MonitorConfig`` from CLI arguments."""
+    if skip_mas and compare_modes:
+        msg = "--skip-mas cannot be combined with --compare-modes"
+        raise ValueError(msg)
     end = parse_window_end(window_end)
     window = build_time_window(window_end=end, window_minutes=window_minutes)
-    if compare_modes:
+    if skip_mas:
+        modes = (SearchMode.ENTITY_ONLY,)
+    elif compare_modes:
         modes = SearchMode.all_modes()
     else:
         modes = (SearchMode.parse(search_mode),)
@@ -312,6 +395,7 @@ def build_config(
         seen_headlines_db=seen_headlines_db,
         force_baseline_refresh=force_baseline_refresh,
         requests_per_minute=requests_per_minute,
+        skip_mas=skip_mas,
     )
 
 

--- a/News_Monitor_MAS/src/client_monitor/retrieval.py
+++ b/News_Monitor_MAS/src/client_monitor/retrieval.py
@@ -5,9 +5,10 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from bigdata_smart_batching import deduplicate_documents, execute_search
+from bigdata_smart_batching import deduplicate_documents, execute_search, plan_search
 
 from src.client_monitor.query import QuerySpec
+from src.client_monitor.window import TimeWindow
 
 logger = logging.getLogger(__name__)
 
@@ -21,6 +22,69 @@ def plan_entity_ids(plan: dict[str, Any]) -> set[str]:
     return entity_ids
 
 
+def patch_plan_window(
+    plan: dict[str, Any],
+    window: TimeWindow,
+    *,
+    entity_search_in: str = "ALL",
+) -> dict[str, Any]:
+    """Overwrite basket timestamps (and entity search_in) to the monitor window."""
+    for basket in plan.get("baskets") or []:
+        basket["period_start"] = window.start_iso
+        basket["period_end"] = window.end_iso
+        query = basket.get("query")
+        if not isinstance(query, dict):
+            continue
+        filters = query.setdefault("filters", {})
+        filters["timestamp"] = {"start": window.start_iso, "end": window.end_iso}
+        entity = filters.get("entity")
+        if isinstance(entity, dict):
+            entity["search_in"] = entity_search_in
+    return plan
+
+
+def plan_entity_only_search(
+    entity_ids: list[str],
+    *,
+    window: TimeWindow,
+    category: dict[str, Any],
+    requests_per_minute: int,
+) -> dict[str, Any]:
+    """Build a smart-batching plan for entity-only search over the full ID list.
+
+    Uses ``plan_search`` (volume densification + very_low packing). Planner dates are
+    day-granular; call ``patch_plan_window`` before execute for the exact ISO window.
+    """
+    if not entity_ids:
+        return {
+            "chunk_upper_bound_estimate": 0,
+            "baskets": [],
+            "planning_metadata": {"total_companies": 0, "skip_mas": True},
+        }
+
+    start_date = window.start.strftime("%Y-%m-%d")
+    end_date = window.end.strftime("%Y-%m-%d")
+    logger.info(
+        "Planning entity-only smart batch for %d entities (%s → %s)",
+        len(entity_ids),
+        start_date,
+        end_date,
+    )
+    plan = plan_search(
+        universe=entity_ids,
+        start_date=start_date,
+        end_date=end_date,
+        text=None,
+        category=category,
+        requests_per_minute=requests_per_minute,
+    )
+    metadata = plan.setdefault("planning_metadata", {})
+    if isinstance(metadata, dict):
+        metadata["skip_mas"] = True
+        metadata["entity_only"] = True
+    return patch_plan_window(plan, window, entity_search_in="ALL")
+
+
 def run_plan_search(
     plan: dict[str, Any],
     *,
@@ -30,6 +94,15 @@ def run_plan_search(
     """Execute one search plan and return deduplicated documents."""
     if not plan.get("baskets"):
         return []
+    expected = int(plan.get("chunk_upper_bound_estimate") or 0)
+    target = int(expected * chunk_percentage)
+    logger.info(
+        "Retrieving %.0f%% of planned chunks (expected=%s → target≈%s) across %s baskets",
+        chunk_percentage * 100.0,
+        f"{expected:,}",
+        f"{target:,}",
+        len(plan.get("baskets") or []),
+    )
     documents = execute_search(
         search_plan=plan,
         chunk_percentage=chunk_percentage,

--- a/News_Monitor_MAS/tests/test_client_monitor.py
+++ b/News_Monitor_MAS/tests/test_client_monitor.py
@@ -8,11 +8,13 @@ from pathlib import Path
 import pytest
 
 from src.client_monitor.config import DEFAULT_SEARCH_CATEGORY, resolve_search_category
-from src.client_monitor.digest import build_alerts_with_stories
+from src.client_monitor.digest import build_alerts_with_stories, build_run_summary
 from src.client_monitor.mas import compute_mas, scale_lambda_from_total
 from src.client_monitor.novelty import headline_hash, mark_syndication, normalize_headline
+from src.client_monitor.pipeline import build_config
 from src.client_monitor.plans import basket_expected_chunks, build_search_plan
 from src.client_monitor.query import QuerySpec, build_entity_wide_spec, build_query_spec
+from src.client_monitor.retrieval import patch_plan_window
 from src.client_monitor.taxonomy import build_taxonomy_index, load_taxonomy
 from src.client_monitor.topics import MONITOR_TOPICS, SearchMode
 from src.client_monitor.volumes import batch_size_for_spec
@@ -113,8 +115,8 @@ def test_comention_payload_includes_topic(sample_window: TimeWindow) -> None:
     assert query["text"] == "Regulatory news"
 
 
-def test_default_search_category_is_news_premium_only() -> None:
-    assert DEFAULT_SEARCH_CATEGORY == {"mode": "INCLUDE", "values": ["news_premium"]}
+def test_default_search_category_is_news() -> None:
+    assert DEFAULT_SEARCH_CATEGORY == {"mode": "INCLUDE", "values": ["news"]}
 
 
 def test_resolve_search_category() -> None:
@@ -312,3 +314,97 @@ def test_build_time_window_from_range() -> None:
     assert window.start_iso == "2026-06-16T05:00:00Z"
     assert window.end_iso == "2026-06-17T04:59:59Z"
     assert window.minutes == 1439
+
+
+def test_patch_plan_window_sets_iso_and_search_in(sample_window: TimeWindow) -> None:
+    plan = {
+        "chunk_upper_bound_estimate": 10,
+        "baskets": [
+            {
+                "basket_id": "b0",
+                "companies": ["E1", "E2"],
+                "expected_chunks": 0,
+                "period_start": "2026-07-17T00:00:00Z",
+                "period_end": "2026-07-17T23:59:59Z",
+                "query": {
+                    "filters": {
+                        "timestamp": {
+                            "start": "2026-07-17T00:00:00Z",
+                            "end": "2026-07-17T23:59:59Z",
+                        },
+                        "entity": {"any_of": ["E1", "E2"], "search_in": "BODY"},
+                    }
+                },
+            }
+        ],
+    }
+    patched = patch_plan_window(plan, sample_window, entity_search_in="ALL")
+    basket = patched["baskets"][0]
+    assert basket["period_start"] == sample_window.start_iso
+    assert basket["period_end"] == sample_window.end_iso
+    assert basket["query"]["filters"]["timestamp"]["start"] == sample_window.start_iso
+    assert basket["query"]["filters"]["entity"]["search_in"] == "ALL"
+
+
+def test_build_run_summary_skip_mas() -> None:
+    summary = build_run_summary(
+        config={"chunk_percentage": 0.5, "skip_mas": True},
+        chunk_rows=[
+            {
+                "entity_id": "E1",
+                "monitor_topic": "entity_wide",
+                "is_primary_story": True,
+                "headline": "Story",
+            }
+        ],
+        mas_rows=[],
+        alerts_with_stories=[],
+        timings={"skip_mas_entity_batch": 1.0},
+        skip_mas=True,
+    )
+    assert summary["mas"]["skipped"] is True
+    assert summary["mas"]["alert_count"] == 0
+    assert summary["mas"]["primary_story_count"] == 1
+    assert summary["retrieval"]["chunk_percentage"] == 0.5
+
+
+def test_build_config_skip_mas_forces_entity_only(tmp_path: Path) -> None:
+    config = build_config(
+        universe_path=tmp_path / "u.csv",
+        taxonomy_path=tmp_path / "t.csv",
+        output_dir=tmp_path / "out",
+        window_end="2026-07-17T12:00:00Z",
+        window_minutes=15,
+        search_mode="topic",
+        compare_modes=False,
+        category_profile="news",
+        chunk_percentage=0.5,
+        limit_entities=10,
+        max_chunks_per_basket=None,
+        seen_headlines_db=None,
+        force_baseline_refresh=False,
+        requests_per_minute=350,
+        skip_mas=True,
+    )
+    assert config.skip_mas is True
+    assert config.search_modes == (SearchMode.ENTITY_ONLY,)
+    assert config.category_profile == "news"
+
+    with pytest.raises(ValueError, match="compare-modes"):
+        build_config(
+            universe_path=tmp_path / "u.csv",
+            taxonomy_path=tmp_path / "t.csv",
+            output_dir=tmp_path / "out",
+            window_end="2026-07-17T12:00:00Z",
+            window_minutes=15,
+            search_mode="topic",
+            compare_modes=True,
+            category_profile="news",
+            chunk_percentage=0.5,
+            limit_entities=0,
+            max_chunks_per_basket=None,
+            seen_headlines_db=None,
+            force_baseline_refresh=False,
+            requests_per_minute=350,
+            skip_mas=True,
+        )


### PR DESCRIPTION
## Summary
- Add `--skip-mas` entity-only path using library `plan_search` over the full universe (including zero-volume names), with no themes/MAS scoring.
- Document at the top of the README how `chunk_percentage` acts as a request budget/cap vs planner expected volume, and why short windows often under-fill.
- Default `--category-profile` to `news` (was `news_premium`).

## Test plan
- [x] `uv run python -m pytest tests/test_client_monitor.py -v` (23 passed)
- [x] Smoke: `uv run client-news-monitor --skip-mas --limit-entities 50 --chunk-percentage 0.5`
- [ ] Confirm README skip-mas section is at the top and `--chunk-percentage` help text is clear


Made with [Cursor](https://cursor.com)