### PR TITLE
Add Edge MRVR news pull to News Monitor MAS

### DIFF
--- a/News_Monitor_MAS/.env.example
+++ b/News_Monitor_MAS/.env.example
@@ -1,1 +1,3 @@
-BIGDATA_API_KEY=your_api_key_here
+RAVENPACK_API_KEY=your_edge_api_key_here
+# Optional: Bigdata enrichment / legacy client-news-monitor CLI
+BIGDATA_API_KEY=your_bigdata_api_key_here

--- a/News_Monitor_MAS/README.md
+++ b/News_Monitor_MAS/README.md
@@ -1,114 +1,235 @@
-# Client News Monitor
+# News Monitor (Edge MRVR)
 
-Retrieval-only news monitor for ~3,000 US small/mid companies over a configurable Bigdata timestamp window. Two modes: **topic + MAS** (default production path) and **`--skip-mas`** (entity-only smart batch over the full universe). No LLM labeling, no MCP.
+Entity-scoped **web/public news** pull from RavenPack **Edge**, provider **`MRVR`**.  
+Deterministic analytics per company–document row, including relevance, sentiment, novelty, **`rp_document_id`**, and optional **`url`**.
 
-Uses [Bigdata.com](https://bigdata.com) smart search and [bigdata-smart-batching](https://docs.bigdata.com/use-cases/search-service/smart-batching). Default document category is **`news`** (override with `--category-profile news_premium`).
+Optional post-processing can use the extracted `rp_document_id` / `url` (URL scrape or Bigdata document fetch) — that step is outside this runner.
 
-## Skip-MAS entity batch (full universe)
-
-`--skip-mas` skips themes and MAS scoring. It hands the full company list to `plan_search` (`text=None`); the library densifies baskets and packs zero-volume names into **`very_low`** groups. Then `execute_search` runs with an explicit **`--chunk-percentage`**.
-
-```bash
-# Full ~3k universe, retrieve 50% of the planned chunk budget
-uv run client-news-monitor \
-  --skip-mas \
-  --chunk-percentage 0.5 \
-  --output-dir runs/skip_mas_3k_50pct
-```
-
-### How planning vs retrieval works
-
-1. **`plan_search`** estimates co-mention volumes (day-granular dates) and builds baskets (volume buckets + dense `very_low` for zeros).
-2. We **patch** each basket’s timestamps to the exact monitor ISO window (often 15 minutes).
-3. **`--chunk-percentage`** sets the retrieval **cap**:  
-   `target ≈ chunk_upper_bound_estimate × chunk_percentage`  
-   Example: expected 76,441 × 0.5 → target ≈ **38,220** max chunks to *request*.
-4. The API only returns what exists in the window. Flattened output is much smaller — e.g. **758 rows / 500 primary** in a quiet 15‑min `news` run.
-
-| Metric | Meaning |
-|--------|---------|
-| Plan expected / target | Upper bound on chunks we are willing to request |
-| `chunk_rows` | Rows in `retrieval_chunks.jsonl` (chunk × matched company) |
-| `primary_stories` | Unique headlines after within-run syndication dedup |
-
-**50% does not mean “retrieve half the universe’s news.”** It means “use half of the planner’s expected-chunk budget as `max_chunks`.” Empty windows and short windows under-fill that budget.
-
-Logs spell this out: `chunk_percentage=50% (expected=4,765 → target≈2,382)`.
-
-## Architecture
-
-```mermaid
-flowchart TB
-  subgraph inputs [Inputs]
-    Universe["us_sml.csv\n~3k RP_ENTITY_ID"]
-    Taxonomy["taxonomy.csv\ncurated topic IDs"]
-    Window["15-min UTC window"]
-    Mode["search mode\ntext | topic | text+topic | entity_only"]
-  end
-
-  subgraph perTopic [Per monitor topic × search mode]
-    QuerySpec["QuerySpec\nshared filters + text/topic"]
-    Vnow["Co-mention volumes\nV_now per entity"]
-    Baseline["MAS baselines\n30d lagged, SQLite cache"]
-    MAS["MAS + PCT_RANK\nper entity × topic"]
-    Plan["Search plan\nfixed baskets, expected_chunks from V_now"]
-    Search["execute_search\nchunk_percentage=0.5"]
-  end
-
-  subgraph novelty [Dedup]
-    HeadlineHash["Headline hash\nprimary vs syndicated"]
-  end
-
-  subgraph outputs [Outputs]
-    Chunks["retrieval_chunks.jsonl"]
-    MAScsv["mas_scores.csv"]
-    Digest["retrieval_digest.json"]
-    Stories["alerts_with_stories.csv"]
-    Summary["run_summary.json\nalerts"]
-  end
-
-  Universe --> QuerySpec
-  Taxonomy --> QuerySpec
-  Window --> QuerySpec
-  Mode --> QuerySpec
-
-  QuerySpec --> Vnow
-  QuerySpec --> Baseline
-  Vnow --> MAS
-  Baseline --> MAS
-  Vnow --> Plan
-  QuerySpec --> Plan
-  Plan --> Search
-  Search --> Chunks
-
-  Chunks --> HeadlineHash
-  HeadlineHash --> Digest
-  MAS --> MAScsv
-  HeadlineHash --> Stories
-  MAS --> Stories
-  HeadlineHash --> Summary
-  MAS --> Summary
-  Digest --> Summary
-```
-
-Each run loops over **4 monitor topics** (`earnings`, `contracts`, `leadership`, `regulatory`) unless `--search-mode entity_only` is set (one entity-wide pass, no taxonomy filter). With `--compare-modes`, the full pipeline runs three times (one per taxonomy search mode).
+---
 
 ## Setup
 
 ```bash
 uv sync
-cp .env.example .env   # set BIGDATA_API_KEY
+cp .env.example .env
+# RAVENPACK_API_KEY  — required for Edge MRVR (scripts/edge_mrvr_stories.py)
+# BIGDATA_API_KEY    — required for client-news-monitor (src/client_monitor)
 ```
 
-Only `BIGDATA_API_KEY` is required. Run commands from this directory so `.env` is loaded automatically.
+Run commands from this directory so `.env` loads automatically.
+
+---
 
 ## Quick start
 
 ```bash
-# Smoke test (50 companies, 15-min window ending now UTC)
+# Last 15 minutes, first 50 names from us_sml.csv
+uv run python scripts/edge_mrvr_stories.py pull \
+  --universe us_sml.csv \
+  --limit-entities 50 \
+  --window-minutes 15 \
+  --output-dir runs/edge_pull_smoke
+
+# Skip URL lookups (saves document-URL quota)
+uv run python scripts/edge_mrvr_stories.py pull \
+  --universe us_sml.csv \
+  --limit-entities 50 \
+  --window-minutes 15 \
+  --skip-urls \
+  --output-dir runs/edge_pull_smoke
+```
+
+`last15` is an alias for `pull`.
+
+---
+
+## Universe (CLI)
+
+Pick **one** way to define the company set:
+
+| Flag | Input | Notes |
+|------|--------|------|
+| `--universe PATH` | CSV with **`RP_ENTITY_ID`** (optional `COMPANY_NAME`, `ticker`) | Preferred for `us_sml.csv` — no ticker mapping calls |
+| `--tickers AAPL,MSFT,...` | Comma-separated tickers | Mapped to RP ids via Edge entity-mapping (+ `us_sml.csv` disambiguation when present) |
+| `--entity-ids 0157B1,4A6F00,...` | Comma-separated RP ids | Skip mapping entirely |
+| `--missed-csv PATH` | CSV with a **`Ticker`** column | Used by `recover`; also a fallback universe for `pull`/`feed` |
+| `--limit-entities N` | Integer | Cap size after load (`0` = all) |
+
+Examples:
+
+```bash
+# Full US small/mid file
+uv run python scripts/edge_mrvr_stories.py pull \
+  --universe us_sml.csv \
+  --window-minutes 15 \
+  --skip-urls \
+  --output-dir runs/edge_us_sml_15m
+
+# Explicit tickers
+uv run python scripts/edge_mrvr_stories.py pull \
+  --tickers AAPL,MSFT,NVDA,GOOG \
+  --window-minutes 15 \
+  --output-dir runs/edge_mega
+
+# Raw RP entity ids
+uv run python scripts/edge_mrvr_stories.py pull \
+  --entity-ids 0157B1,4A6F00,D6489C \
+  --window-minutes 15 \
+  --output-dir runs/edge_ids
+```
+
+Resolved mappings are written to `{output-dir}/entity_mapping.csv` and **reused** on later runs in the same output directory (avoids remapping rate limits).
+
+---
+
+## Time range (CLI)
+
+All times are **UTC**. Two styles:
+
+### A) Rolling window ending at `--window-end` (default: now)
+
+```bash
+# Last 15 minutes ending now
+--window-minutes 15
+
+# Last 60 minutes ending at a fixed instant
+--window-end 2026-07-29T15:00:00Z --window-minutes 60
+```
+
+### B) Explicit interval
+
+```bash
+--start 2026-07-28T12:00:00Z --end 2026-07-28T12:15:00Z
+```
+
+ISO forms with `Z` or `+00:00` are accepted. `--start` / `--end` must be used together; when set, they override `--window-minutes` / `--window-end`.
+
+Examples:
+
+```bash
+# Fixed 15-minute bucket
+uv run python scripts/edge_mrvr_stories.py pull \
+  --universe us_sml.csv \
+  --limit-entities 100 \
+  --start 2026-07-29T07:13:00Z \
+  --end 2026-07-29T07:28:00Z \
+  --skip-urls \
+  --output-dir runs/edge_fixed_window
+
+# One hour ending at noon UTC
+uv run python scripts/edge_mrvr_stories.py pull \
+  --tickers AAPL,AMZN \
+  --window-end 2026-07-29T12:00:00Z \
+  --window-minutes 60 \
+  --output-dir runs/edge_hour
+```
+
+`feed` mode always uses rolling buckets of `--interval-minutes` (default 15) ending at “now” for each bucket.
+
+---
+
+## Modes
+
+| Mode | Purpose |
+|------|---------|
+| `pull` / `last15` | One-shot pull for a universe + time window |
+| `feed` | Poll successive buckets (`--interval-minutes`, `--max-buckets`) |
+| `recover` | Historical pull + match against `--missed-csv` (MissedStories-shaped) |
+
+```bash
+# Continuous feed: one bucket then exit
+uv run python scripts/edge_mrvr_stories.py feed \
+  --universe us_sml.csv \
+  --limit-entities 50 \
+  --interval-minutes 15 \
+  --max-buckets 1 \
+  --skip-urls \
+  --output-dir runs/edge_feed
+
+# MissedStories recovery (uses datafile for long ranges)
+uv run python scripts/edge_mrvr_stories.py recover \
+  --missed-csv MissedStories.csv \
+  --skip-urls \
+  --output-dir runs/edge_missed_recovery
+```
+
+---
+
+## Output columns
+
+`stories_unique.csv`:
+
+| Column | Description |
+|--------|-------------|
+| `timestamp_utc` | Story timestamp |
+| `company_name` | Entity name |
+| `title` | Headline |
+| `source_name` | Publisher |
+| `url` | Article URL (from `get_document_url(rp_document_id)`; empty with `--skip-urls`) |
+| `entity_relevance` | How central the company is (≥ 90 ≈ headline / lead) |
+| `entity_sentiment` | Sentiment on entity-related text/events |
+| `title_similarity_days` | Novelty — days since a similar title (≥ 90 ≈ quarterly-new; &lt; 1 ≈ same-day reprint) |
+| `rp_document_id` | Stable document id (dedup + enrichment key) |
+
+Also written: `raw_records.csv`, `entity_mapping.csv`, `dataset_id.txt`, `run_summary.json`.
+
+### Optional filters (post-pull or via `--min-entity-relevance`)
+
+```text
+entity_relevance       >= 90
+title_similarity_days  >= 90
+```
+
+`--min-entity-relevance 90` applies the relevance floor in the Edge query itself.
+
+---
+
+## Post-processing hooks
+
+Every kept row carries:
+
+- **`rp_document_id`** — deterministic key for document-level enrichment  
+- **`url`** — optional open/scrape target (when not using `--skip-urls`)
+
+Typical follow-ons: URL scrape, or fetch a full annotated document by id in a downstream system.
+
+---
+
+## CLI reference
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `mode` | required | `pull` \| `last15` \| `feed` \| `recover` |
+| `--universe` | — | CSV with `RP_ENTITY_ID` |
+| `--tickers` | — | Comma-separated tickers |
+| `--entity-ids` | — | Comma-separated RP ids |
+| `--missed-csv` | `MissedStories.csv` | Tickers file / recover input |
+| `--limit-entities` | `0` | Cap universe size |
+| `--start` / `--end` | — | Explicit UTC window |
+| `--window-end` | now | End of rolling window |
+| `--window-minutes` | `15` | Rolling window length |
+| `--interval-minutes` | `15` | Feed bucket length |
+| `--max-buckets` | `1` | Feed iterations (`0` = forever) |
+| `--min-entity-relevance` | none | Query-time relevance floor |
+| `--skip-urls` | off | Skip URL resolution |
+| `--output-dir` | `runs/edge_<mode>_<ts>` | Output directory |
+| `-v` | off | Verbose logging |
+
+---
+
+## Bigdata.com monitor (`client-news-monitor`)
+
+Also in this repo: a retrieval-only Bigdata.com news monitor over ~3k US names (`us_sml.csv`), with optional topic filters + MAS, or entity-only smart batching (`--skip-mas`). Package: `src/client_monitor/`. Entry point: `uv run client-news-monitor`.
+
+Requires `BIGDATA_API_KEY` in `.env`. Uses [Bigdata.com](https://bigdata.com) smart search and [bigdata-smart-batching](https://docs.bigdata.com/use-cases/search-service/smart-batching). Default document category is **`news`**.
+
+### Quick start
+
+```bash
+# Smoke (50 companies, last 15 minutes ending now UTC)
 uv run client-news-monitor --limit-entities 50
 
-# Full PoC (~3k names from us_sml.csv)
+# Full universe, topic + text search
 uv run client-news-monitor \
   --universe us_sml.csv \
   --taxonomy taxonomy.csv \
@@ -116,147 +237,78 @@ uv run client-news-monitor \
   --chunk-percentage 0.5 \
   --output-dir runs/client_poc
 
-# Narrower premium category
-uv run client-news-monitor --category-profile news_premium --limit-entities 50
-
-# Compare text / topic / text+topic (~3× retrieval cost)
-uv run client-news-monitor ... --compare-modes
-
-# Skip MAS: entity-only smart batch over all names (library densifies zero-volume)
+# Entity-only smart batch (no themes / no MAS)
 uv run client-news-monitor \
   --skip-mas \
   --chunk-percentage 0.5 \
   --limit-entities 50 \
   --output-dir runs/skip_mas_50pct
+
+# Fixed window end
+uv run client-news-monitor \
+  --universe us_sml.csv \
+  --window-end 2026-07-29T15:00:00Z \
+  --window-minutes 15 \
+  --skip-mas \
+  --chunk-percentage 0.5 \
+  --output-dir runs/skip_mas_fixed
 ```
 
-## What it does
+### Universe & time
 
-For each of **4 monitor topics** (`earnings`, `contracts`, `leadership`, `regulatory`):
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--universe` | `us_sml.csv` | CSV with `RP_ENTITY_ID`, `COMPANY_NAME` |
+| `--limit-entities` | `0` (all) | First N rows of the universe |
+| `--window-end` | now (UTC) | ISO end of the monitor window |
+| `--window-minutes` | `15` | Window length ending at `--window-end` |
 
-1. **Co-mention volume** — per-entity chunk counts (`V_now`) in the window
-2. **Retrieval** — smart-batched search at `--chunk-percentage 0.5`; skips zero-volume baskets
-3. **MAS scoring** — Media Attention Score vs a cached 30-day baseline (same query spec)
-4. **Syndication dedup** — headline-hash collapse within the run
+### Search modes & skip-MAS
 
-**Document category:** controlled by `--category-profile` (default `news`). Use `news_premium` for narrower premium coverage; `news` includes broader wire coverage at the cost of more noise.
+| Mode / flag | Behavior |
+|-------------|----------|
+| `--search-mode text` | Document-voice text query; entity in `BODY` |
+| `--search-mode topic` | Curated taxonomy topic IDs only |
+| `--search-mode text+topic` | Text + topic (default) |
+| `--search-mode entity_only` | No taxonomy filter; entity `search_in=ALL` (one `entity_wide` pass) |
+| `--compare-modes` | Run `text`, `topic`, and `text+topic` sequentially |
+| `--skip-mas` | Skip themes and MAS; `plan_search` + `execute_search` over all companies (including zero-volume densified baskets). `--chunk-percentage` is the retrieval budget |
 
-## MAS scoring
+`--chunk-percentage` is a fraction of the planner’s expected-chunk upper bound (e.g. `0.5` = 50% of that budget), not “half the universe’s news.”
 
-**Media Attention Score (MAS)** flags entities whose news volume in the current window is unusually high relative to their own recent history. It uses the **same `QuerySpec`** as retrieval (monitor topic, search mode, category, text/topic filters) so volume, baselines, and search stay aligned.
+### Monitor topics
 
-### Step 1 — Current volume (`V_now`)
+When not using `--skip-mas` / `entity_only`, the pipeline loops four topics from `taxonomy.csv` (`TOPIC=business`), defined in `src/client_monitor/topics.py`:
 
-For each entity, call Bigdata **co-mention volume** over the run window. `V_now` is the chunk count returned for that entity under the active query spec.
+| Topic | Focus |
+|-------|--------|
+| `earnings` | Earnings, results, analyst ratings |
+| `contracts` | Contracts, partnerships, awards |
+| `leadership` | Executive / board changes |
+| `regulatory` | Regulatory / legal / government |
 
-### Step 2 — Baseline (`λ`, stored as `LAMBDA_BUCKET`)
-
-On first run (or with `--force-baseline-refresh`), fetch co-mention volumes over a **lagged 30-day window** ending **1 day before** the current window end. Results are cached in `mas_baselines.db`, keyed by `(query_hash, entity_id)`.
-
-The baseline is scaled to the current bucket length:
-
-```
-λ = (volume_30d / minutes_in_30d) × window_minutes
-```
-
-For a 15-minute run, `λ` is the expected chunk count in 15 minutes given the prior 30 days.
-
-### Step 3 — Score (0–100)
-
-For each entity with `V_now > 0`:
-
-| Metric | Formula | Meaning |
-|--------|---------|---------|
-| **MAR** | `(V_now + 1) / (λ + 1)` | Raw volume ratio vs baseline |
-| **Z** | `(V_now − λ) / √(λ + 1)` | Poisson-style surprise |
-| **MAS** | `min(100, 100 × sigmoid(Z / 5) × log1p(V_now) / log1p(λ + 10))` | Combined surprise × magnitude |
-
-If `V_now = 0`, **MAS = 0**.
-
-Implementation: `src/client_monitor/mas.py`.
-
-### Step 4 — Rank and alert
-
-Within each monitor topic, entities are assigned **PCT_RANK** (0–100, ascending by `V_now` then `Z`).
-
-An **alert** fires when either:
-
-1. **High MAS** — entity is in the **top ~1%** `PCT_RANK` for that topic *and* `MAS > 0`, or
-2. **Primary chunk** — entity has at least one **primary** retrieved story in that topic (after syndication dedup).
-
-`alerts_with_stories.csv` keeps only alerts that also have a primary chunk (inner join). MAS-only alerts appear in `run_summary.json` and `mas_scores.csv` but not in the story feed.
-
-## Monitor topics
-
-Curated topic filters from `taxonomy.csv` (`TOPIC=business`). Rules in `src/client_monitor/topics.py`.
-
-| Topic | Document-voice text | Taxonomy rule | ~topic IDs |
-|-------|---------------------|---------------|------------|
-| `earnings` | Earnings, financial results, analyst ratings | GROUPs: `earnings`, `revenues`, `dividends`, `analyst-ratings` | ~211 |
-| `contracts` | Contracts, partnerships, strategic developments | All `partnerships` + `products-services` types: `business-contract`, `government-contract`, `award` | ~19 |
-| `leadership` | Executive/leadership changes | `labor-issues` types: `executive-*`, `board-member-*`, `board-diversity` | ~37 |
-| `regulatory` | Regulatory/legal/government news | All `regulatory` GROUP | ~22 |
-
-## CLI reference
+### CLI reference (`client-news-monitor`)
 
 | Option | Default | Description |
 |--------|---------|-------------|
-| `--universe` | `us_sml.csv` | CSV with `RP_ENTITY_ID`, `COMPANY_NAME` |
+| `--universe` | `us_sml.csv` | Universe CSV |
 | `--taxonomy` | `taxonomy.csv` | Bigdata taxonomy CSV |
-| `--output-dir` | `runs/client_poc_<timestamp>` | Run output directory |
-| `--window-end` | now (UTC) | Window end ISO timestamp |
-| `--window-minutes` | `15` | Window length in minutes |
-| `--search-mode` | `text+topic` | `text`, `topic`, `text+topic`, or `entity_only` |
-| `--skip-mas` | off | Entity-only smart batch over all companies; no themes/MAS |
-| `--category-profile` | `news` | `news` or `news_premium` |
-| `--compare-modes` | off | Run all three search modes |
-| `--chunk-percentage` | `0.5` | Fraction of plan expected chunks to retrieve (0–1; **50%** default) |
-| `--limit-entities` | `0` (all) | Limit to first N companies |
+| `--output-dir` | `runs/client_poc_<timestamp>` | Output directory |
+| `--window-end` | now (UTC) | Window end ISO |
+| `--window-minutes` | `15` | Window length |
+| `--search-mode` | `text+topic` | `text` \| `topic` \| `text+topic` \| `entity_only` |
+| `--compare-modes` | off | Run three taxonomy modes |
+| `--skip-mas` | off | Entity-only smart batch; no themes/MAS |
+| `--category-profile` | `news` | `news` \| `news_premium` |
+| `--chunk-percentage` | `0.5` | Fraction of plan expected chunks to retrieve |
+| `--limit-entities` | `0` | Cap universe size |
 | `--max-chunks-per-basket` | none | Hard cap on `max_chunks` |
-| `--seen-headlines-db` | none | Optional SQLite for cross-run headline dedup |
-| `--force-baseline-refresh` | off | Re-fetch 30-day MAS baselines |
+| `--seen-headlines-db` | none | SQLite for cross-run headline dedup |
+| `--force-baseline-refresh` | off | Refresh 30-day MAS baselines |
 | `--requests-per-minute` | `350` | Bigdata search rate limit |
+| `-v` | off | Debug logging |
 
-### Search modes
-
-| Mode | `query.text` | `filters.topic` | Entity `search_in` |
-|------|--------------|-----------------|-------------------|
-| `text` | document-voice string | omitted | `BODY` |
-| `topic` | omitted | curated taxonomy IDs | `BODY` |
-| `text+topic` | document-voice string | curated taxonomy IDs | `BODY` |
-| `entity_only` | omitted | omitted | `ALL` |
-
-`entity_only` runs **once per search mode** with `monitor_topic=entity_wide` — all news about the entity in the window, not scoped to the four monitor topics. See [Targeted backfill](#targeted-backfill-recommended-not-automated) below.
-
-### Skip MAS (entity-only smart batch)
-
-`--skip-mas` turns off themes and MAS scoring. It calls `bigdata_smart_batching.plan_search` on the full universe (`text=None`) so the library densifies baskets and packs zero-volume names into `very_low` groups, then `execute_search` with **`--chunk-percentage`** as the retrieval budget.
-
-Example: `--chunk-percentage 0.5` means retrieve **50%** of the plan’s `chunk_upper_bound_estimate`. Basket timestamps are patched to the exact monitor ISO window after planning.
-
-### Targeted backfill (recommended, not automated)
-
-**Targeted backfill** is a second retrieval pass for a **small set of names that already look interesting**, not entity-wide search on the full ~3k universe every 15 minutes.
-
-**Primary pass (production default):** topic-scoped retrieval + MAS on the full universe. Alerts fire when a company is in the top 1% MAS for a topic or has a primary retrieved chunk. Many alerts are **MAS-only** — volume spiked, but no story passed the topic filter — and those are omitted from `alerts_with_stories.csv`.
-
-**Backfill pass (proposed):** for entities with a MAS alert and **no** primary chunk in that topic, run `entity_only` search for **that entity only** in the same window. This can recover stories outside the four taxonomy lanes (e.g. a partnership wire tagged outside `contracts`) without paying the cost of brute entity search on every name.
-
-| | Full-universe `entity_only` every 15 min | Targeted backfill |
-|---|------------------------------------------|-------------------|
-| Scope | All ~3k entities | MAS-fired entities with no story (typically tens, not thousands) |
-| Query | `entity_only` | Same |
-| Cost | Prohibitive at scale | Bounded by alert count |
-
-**Status:** `entity_only` is implemented as a CLI search mode. The **automatic** MAS-triggered second pass is **not** wired into `pipeline.py` yet.
-
-**Manual approximation today:**
-
-1. Run the primary pass with default `--search-mode text+topic` (or `topic`).
-2. From `run_summary.json` or `mas_scores.csv`, identify `(entity_id, monitor_topic)` pairs that alerted but have no row in `alerts_with_stories.csv`.
-3. Run `entity_only` on a trimmed universe containing only those entities (custom CSV or `--limit-entities` on a filtered list).
-
-## Output artifacts
+### Outputs (`client-news-monitor`)
 
 ```
 {output_dir}/
@@ -270,29 +322,26 @@ Example: `--chunk-percentage 0.5` means retrieve **50%** of the plan’s `chunk_
   run_summary.json
 ```
 
-Alerts in `run_summary.json` fire when a company is in the **top 1% MAS** for a topic or has a **primary retrieved chunk** in that topic.
+Alerts fire when a company is in the top 1% MAS for a topic or has a primary retrieved chunk. `alerts_with_stories.csv` is the inner join of alerts with primary stories.
 
-`alerts_with_stories.csv` is the **inner join** of those alerts with primary chunks: MAS-only alerts are omitted. One row per `(entity_id, monitor_topic, document_id)` story, sorted by MAS then relevance.
-
-## Tests
+### Tests
 
 ```bash
 uv run python -m pytest tests/test_client_monitor.py -v
 uv run ruff check src/client_monitor tests
 ```
 
-## Cost notes
-
-- **Volume pass:** ~60–80 co-mention calls per monitor topic for ~3k entities
-- **Baselines:** cached in `mas_baselines.db` after first run per `(topic, search_mode)`
-- **Retrieval:** only baskets with `V_now > 0`; default 50% chunk sampling
-- **Pricing:** $0.015 per 10 chunks retrieved
+---
 
 ## Project layout
 
 ```
-src/client_monitor/   # pipeline modules
-taxonomy.csv          # Bigdata topic taxonomy (business rows)
-us_sml.csv            # default universe (~3k US small/mid names)
-runs/                 # run outputs (gitignored recommended)
+scripts/edge_mrvr_stories.py   # Edge MRVR runner (pull / feed / recover)
+scripts/edge_match_offline.py  # Offline MissedStories rematch helper (if present)
+src/client_monitor/            # Bigdata monitor package → client-news-monitor CLI
+taxonomy.csv                   # Bigdata topic taxonomy (business rows)
+us_sml.csv                     # Default universe (~3k US names, RP_ENTITY_ID)
+tests/                         # client_monitor unit tests
+runs/                          # Run outputs
+.env.example                   # RAVENPACK_API_KEY, BIGDATA_API_KEY
 ```

--- a/News_Monitor_MAS/pyproject.toml
+++ b/News_Monitor_MAS/pyproject.toml
@@ -7,6 +7,7 @@ dependencies = [
     "bigdata-smart-batching>=1.3.1,<2.0.0",
     "pandas>=2.0.0",
     "python-dotenv>=1.0.0",
+    "ravenpackapi>=1.1.6",
     "requests>=2.31.0",
 ]
 

--- a/News_Monitor_MAS/scripts/edge_match_offline.py
+++ b/News_Monitor_MAS/scripts/edge_match_offline.py
@@ -1,0 +1,183 @@
+"""Fast offline match of MissedStories against an Edge datafile CSV."""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+import time
+from pathlib import Path
+
+import pandas as pd
+from dotenv import load_dotenv
+from ravenpackapi import RPApi
+
+logger = logging.getLogger("edge_match_offline")
+
+
+def normalize_title(text: str) -> str:
+    cleaned = str(text).lower()
+    cleaned = re.sub(r"\s*\|\s*.*$", "", cleaned)
+    cleaned = re.sub(r"[^a-z0-9\s]", " ", cleaned)
+    cleaned = re.sub(r"\s+", " ", cleaned).strip()
+    return cleaned
+
+
+def title_similarity(a: str, b: str) -> float:
+    na, nb = normalize_title(a), normalize_title(b)
+    if not na or not nb:
+        return 0.0
+    if na == nb:
+        return 1.0
+    if na in nb or nb in na:
+        return 0.95
+    ta, tb = set(na.split()), set(nb.split())
+    if not ta or not tb:
+        return 0.0
+    return len(ta & tb) / len(ta | tb)
+
+
+def main() -> int:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+    load_dotenv(Path.cwd() / ".env", override=False)
+    import os
+
+    out = Path("runs/edge_missed_recovery")
+    mapping = pd.read_csv(out / "entity_mapping.csv")
+    missed = pd.read_csv("MissedStories.csv", sep=";")
+    missed.columns = [c.strip() for c in missed.columns]
+    missed = missed.loc[:, [c for c in missed.columns if c]]
+    missed["Ticker"] = missed["Ticker"].astype(str).str.strip().str.upper()
+    missed["Pub Date"] = pd.to_datetime(missed["Pub Date"], errors="coerce")
+
+    logger.info("Loading datafile…")
+    edge = pd.read_csv(
+        out / "datafile_raw.csv",
+        usecols=lambda c: str(c).lower()
+        in {
+            "timestamp_utc",
+            "entity_name",
+            "title",
+            "source_name",
+            "rp_document_id",
+            "rp_entity_id",
+        },
+    )
+    edge.columns = [str(c).strip().lower() for c in edge.columns]
+    logger.info("Loaded %d edge rows", len(edge))
+
+    entity_to_ticker = dict(
+        zip(mapping["rp_entity_id"].astype(str), mapping["ticker"].astype(str), strict=True)
+    )
+    edge["ticker"] = edge["rp_entity_id"].astype(str).map(entity_to_ticker)
+    edge = edge.dropna(subset=["ticker", "title"]).copy()
+    edge["title_norm"] = edge["title"].map(normalize_title)
+
+    # Exact / containment prefilter via normalized title sets per ticker
+    by_ticker: dict[str, pd.DataFrame] = {
+        str(t): g.reset_index(drop=True) for t, g in edge.groupby("ticker", sort=False)
+    }
+
+    threshold = 0.72
+    match_rows: list[dict[str, object]] = []
+    matched_doc_ids: set[str] = set()
+
+    for i, story in missed.iterrows():
+        ticker = str(story["Ticker"]).upper()
+        headline = str(story["Headline"])
+        hnorm = normalize_title(headline)
+        candidates = by_ticker.get(ticker)
+        best_score = 0.0
+        best: dict[str, object] = {}
+        if candidates is not None and not candidates.empty:
+            # Prefer exact / containment first
+            exact = candidates[candidates["title_norm"] == hnorm]
+            if not exact.empty:
+                row = exact.iloc[0]
+                best_score = 1.0
+                best = row.to_dict()
+            else:
+                # Containment either direction
+                contain_mask = candidates["title_norm"].map(
+                    lambda t: bool(t) and (hnorm in t or t in hnorm)
+                )
+                contain = candidates[contain_mask]
+                pool = contain if not contain.empty else candidates
+                # Cap scoring work for huge tickers
+                if len(pool) > 5000:
+                    # token overlap prefilter: require >=50% of headline tokens
+                    tokens = set(hnorm.split())
+                    if tokens:
+                        min_hit = max(1, len(tokens) // 2)
+
+                        def _keep(t: str) -> bool:
+                            return len(tokens & set(str(t).split())) >= min_hit
+
+                        mask = pool["title_norm"].map(_keep)
+                        pool = pool[mask]
+                    pool = pool.head(5000)
+                for _, cand in pool.iterrows():
+                    score = title_similarity(headline, str(cand["title"]))
+                    if score > best_score:
+                        best_score = score
+                        best = cand.to_dict()
+        matched = best_score >= threshold
+        doc_id = str(best.get("rp_document_id") or "") if matched else ""
+        if matched and doc_id:
+            matched_doc_ids.add(doc_id)
+        match_rows.append(
+            {
+                "ticker": ticker,
+                "missed_headline": headline,
+                "publisher": story.get("Publisher"),
+                "pub_date": story.get("Pub Date"),
+                "matched": matched,
+                "match_score": round(best_score, 3),
+                "edge_title": best.get("title", "") if matched else "",
+                "edge_source": best.get("source_name", "") if matched else "",
+                "edge_timestamp_utc": best.get("timestamp_utc", "") if matched else "",
+                "rp_document_id": doc_id,
+                "edge_url": "",
+            }
+        )
+        if (i + 1) % 50 == 0:
+            logger.info("Matched %d / %d stories…", i + 1, len(missed))
+
+    api_key = os.getenv("RAVENPACK_API_KEY") or os.getenv("RP_API_KEY")
+    if api_key and matched_doc_ids:
+        api = RPApi(api_key=api_key, product="edge")
+        api.log_curl_commands = False
+        url_cache: dict[str, str] = {}
+        for doc_id in sorted(matched_doc_ids):
+            try:
+                url_cache[doc_id] = str(api.get_document_url(doc_id) or "")
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("URL fail %s: %s", doc_id, exc)
+                url_cache[doc_id] = ""
+            time.sleep(0.02)
+        for row in match_rows:
+            doc_id = str(row.get("rp_document_id") or "")
+            if doc_id:
+                row["edge_url"] = url_cache.get(doc_id, "")
+
+    matches = pd.DataFrame(match_rows)
+    matches.to_csv(out / "missed_match_report.csv", index=False)
+    matched_n = int(matches["matched"].sum())
+    summary = {
+        "mode": "recover_offline",
+        "missed_stories": int(len(missed)),
+        "matched": matched_n,
+        "match_rate": round(matched_n / len(missed), 4) if len(missed) else 0.0,
+        "match_threshold": threshold,
+        "edge_rows": int(len(edge)),
+        "provider": "MRVR",
+        "note": "MRVR-only; premium publishers may be out of scope",
+    }
+    (out / "run_summary.json").write_text(json.dumps(summary, indent=2, default=str), encoding="utf-8")
+    logger.info("Done — matched %d / %d (%.1f%%)", matched_n, len(missed), 100 * summary["match_rate"])
+    print(json.dumps(summary, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/News_Monitor_MAS/scripts/edge_mrvr_stories.py
+++ b/News_Monitor_MAS/scripts/edge_mrvr_stories.py
@@ -1,0 +1,1083 @@
+"""RavenPack Edge MRVR story pull — entity-scoped web news.
+
+Edge 1.0 does **not** accept ``url`` as a dataset field. URLs are resolved via
+``api.get_document_url(rp_document_id)``.
+
+Dataset filters always include ``rp_provider_id=MRVR``. Optional
+``--min-entity-relevance 90`` adds an entity_relevance floor.
+
+Universe (pick one)::
+
+    --universe us_sml.csv              # CSV with RP_ENTITY_ID [, COMPANY_NAME]
+    --tickers AAPL,MSFT,NVDA           # map tickers → RP ids via Edge
+    --entity-ids 0157B1,4A6F00         # raw RP entity ids
+    --missed-csv MissedStories.csv     # tickers from Ticker column (recover default)
+
+Time range (UTC)::
+
+    --window-minutes 15                # end=now, start=now-15m  (default for pull/feed)
+    --window-end 2026-07-29T15:00:00Z --window-minutes 60
+    --start 2026-07-01T00:00:00Z --end 2026-07-02T00:00:00Z
+
+Examples::
+
+    uv run python scripts/edge_mrvr_stories.py pull \\
+      --universe us_sml.csv --limit-entities 50 --window-minutes 15
+
+    uv run python scripts/edge_mrvr_stories.py pull \\
+      --tickers AAPL,MSFT --start 2026-07-28T12:00:00Z --end 2026-07-28T12:15:00Z
+
+    uv run python scripts/edge_mrvr_stories.py recover --missed-csv MissedStories.csv
+    uv run python scripts/edge_mrvr_stories.py feed --universe us_sml.csv --max-buckets 1
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import re
+import time
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+from dotenv import load_dotenv
+from ravenpackapi import Dataset, RPApi
+
+logger = logging.getLogger("edge_mrvr_stories")
+
+OUTPUT_COLUMNS = (
+    "timestamp_utc",
+    "company_name",
+    "title",
+    "source_name",
+    "url",
+    "entity_relevance",
+    "entity_sentiment",
+    "title_similarity_days",
+    "rp_document_id",
+)
+# Edge 1.0 does not expose `url` as an analytics field; resolve via document endpoint.
+INTERNAL_FIELDS = [
+    "timestamp_utc",
+    "entity_name",
+    "title",
+    "source_name",
+    "rp_document_id",
+    "rp_entity_id",
+    "entity_relevance",
+    "entity_sentiment",
+    "title_similarity_days",
+]
+PROVIDER_MRVR = "MRVR"
+DATASET_NAME = "publicAI-edge-mrvr-stories"
+
+
+def load_api_key() -> str:
+    load_dotenv(Path.cwd() / ".env", override=False)
+    import os
+
+    key = os.getenv("RAVENPACK_API_KEY") or os.getenv("RP_API_KEY")
+    if not key:
+        msg = "RAVENPACK_API_KEY (or RP_API_KEY) is not set"
+        raise SystemExit(msg)
+    return key
+
+
+def make_api() -> RPApi:
+    api = RPApi(api_key=load_api_key(), product="edge")
+    api.log_curl_commands = False  # avoid leaking API key into logs
+    return api
+
+
+def read_missed_stories(path: Path) -> pd.DataFrame:
+    df = pd.read_csv(path, sep=";")
+    df.columns = [c.strip() for c in df.columns]
+    # Drop empty trailing columns from trailing semicolons
+    df = df.loc[:, [c for c in df.columns if c]]
+    required = {"Ticker", "Headline", "Publisher", "Pub Date"}
+    missing = required - set(df.columns)
+    if missing:
+        msg = f"MissedStories missing columns: {missing}"
+        raise ValueError(msg)
+    df["Ticker"] = df["Ticker"].astype(str).str.strip().str.upper()
+    df["Headline"] = df["Headline"].astype(str)
+    df["Pub Date"] = pd.to_datetime(df["Pub Date"], errors="coerce")
+    return df.dropna(subset=["Ticker", "Headline"]).reset_index(drop=True)
+
+
+def unique_tickers(missed: pd.DataFrame) -> list[str]:
+    return sorted({t for t in missed["Ticker"].tolist() if t and t != "TICKER"})
+
+
+def parse_utc(value: str) -> datetime:
+    """Parse an ISO / Edge-friendly UTC timestamp."""
+    text = value.strip().replace("Z", "+00:00")
+    dt = datetime.fromisoformat(text)
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=UTC)
+    return dt.astimezone(UTC)
+
+
+def resolve_time_window(
+    *,
+    start: str | None,
+    end: str | None,
+    window_end: str | None,
+    window_minutes: int,
+) -> tuple[datetime, datetime]:
+    """Resolve ``[start, end)`` in UTC.
+
+    Priority:
+    1. ``--start`` + ``--end``
+    2. ``--window-end`` (or now) minus ``--window-minutes``
+    """
+    if start is not None and end is not None:
+        start_dt = parse_utc(start)
+        end_dt = parse_utc(end)
+        if start_dt >= end_dt:
+            msg = f"--start ({start_dt.isoformat()}) must be before --end ({end_dt.isoformat()})"
+            raise SystemExit(msg)
+        return start_dt, end_dt
+    if start is not None or end is not None:
+        raise SystemExit("Provide both --start and --end, or use --window-minutes / --window-end")
+    if window_minutes <= 0:
+        raise SystemExit("--window-minutes must be > 0")
+    end_dt = parse_utc(window_end) if window_end else datetime.now(UTC).replace(microsecond=0)
+    start_dt = end_dt - timedelta(minutes=window_minutes)
+    return start_dt, end_dt
+
+
+def load_universe_csv(path: Path) -> pd.DataFrame:
+    """Load a universe CSV with RP_ENTITY_ID or rp_entity_id."""
+    frame = pd.read_csv(path)
+    frame.columns = [str(c).strip() for c in frame.columns]
+    cols = {c.lower(): c for c in frame.columns}
+    id_col = cols.get("rp_entity_id")
+    if id_col is None:
+        msg = f"{path} must contain RP_ENTITY_ID (found: {list(frame.columns)})"
+        raise SystemExit(msg)
+    name_col = cols.get("company_name") or cols.get("entity_name")
+    ticker_col = cols.get("ticker")
+    out = pd.DataFrame(
+        {
+            "rp_entity_id": frame[id_col].astype(str).str.strip().str.upper(),
+            "entity_name": frame[name_col].astype(str) if name_col else "",
+            "ticker": frame[ticker_col].astype(str).str.upper().str.strip() if ticker_col else "",
+            "map_source": "universe_csv",
+        }
+    )
+    out = out.loc[out["rp_entity_id"].astype(bool)].drop_duplicates(subset=["rp_entity_id"])
+    return out.reset_index(drop=True)
+
+
+def resolve_entity_mapping(
+    api: RPApi,
+    *,
+    output_dir: Path,
+    universe: Path | None,
+    tickers: str | None,
+    entity_ids: str | None,
+    missed_csv: Path | None,
+    limit_entities: int,
+    reuse_mapping: bool,
+    us_sml_path: Path | None = Path("us_sml.csv"),
+) -> pd.DataFrame:
+    """Build ticker/entity mapping from CLI universe options."""
+    mapping_path = output_dir / "entity_mapping.csv"
+    if reuse_mapping and mapping_path.exists():
+        logger.info("Reusing entity mapping from %s", mapping_path)
+        mapping = pd.read_csv(mapping_path)
+        mapping["rp_entity_id"] = mapping["rp_entity_id"].astype(str)
+        if "ticker" in mapping.columns:
+            mapping["ticker"] = mapping["ticker"].astype(str).str.upper()
+        if limit_entities > 0:
+            mapping = mapping.head(limit_entities)
+        return mapping.reset_index(drop=True)
+
+    if universe is not None:
+        mapping = load_universe_csv(universe)
+    elif entity_ids:
+        ids = [x.strip().upper() for x in entity_ids.split(",") if x.strip()]
+        mapping = pd.DataFrame(
+            {
+                "ticker": [""] * len(ids),
+                "rp_entity_id": ids,
+                "entity_name": [""] * len(ids),
+                "map_source": ["cli_entity_ids"] * len(ids),
+            }
+        )
+    elif tickers:
+        ticker_list = [x.strip().upper() for x in tickers.split(",") if x.strip()]
+        mapping = map_tickers(api, ticker_list, us_sml_path=us_sml_path)
+    elif missed_csv is not None and missed_csv.exists():
+        missed = read_missed_stories(missed_csv)
+        mapping = map_tickers(api, unique_tickers(missed), us_sml_path=us_sml_path)
+    else:
+        raise SystemExit(
+            "Provide a universe via --universe, --tickers, --entity-ids, or --missed-csv"
+        )
+
+    if limit_entities > 0:
+        mapping = mapping.head(limit_entities).reset_index(drop=True)
+    mapping.to_csv(mapping_path, index=False)
+    return mapping
+
+
+def map_tickers(
+    api: RPApi,
+    tickers: list[str],
+    *,
+    us_sml_path: Path | None = Path("us_sml.csv"),
+    trusted_ids: dict[str, str] | None = None,
+) -> pd.DataFrame:
+    """Map tickers to Edge rp_entity_id with US-listing disambiguation.
+
+    Prefer (in order): trusted audit ids, listing-qualified COMP matches that land
+    in ``us_sml.csv``, then bare COMP candidates in ``us_sml``, else best COMP hit.
+    """
+    us_ids: set[str] = set()
+    us_name: dict[str, str] = {}
+    if us_sml_path is not None and us_sml_path.exists():
+        us = pd.read_csv(us_sml_path)
+        us_ids = set(us["RP_ENTITY_ID"].astype(str))
+        us_name = dict(
+            zip(us["RP_ENTITY_ID"].astype(str), us["COMPANY_NAME"].astype(str), strict=True)
+        )
+
+    trusted_ids = trusted_ids or {}
+    rows: list[dict[str, str]] = []
+
+    for ticker in tickers:
+        ticker_u = ticker.upper()
+        chosen_id = ""
+        chosen_name = ""
+        source = ""
+
+        if ticker_u in trusted_ids:
+            chosen_id = str(trusted_ids[ticker_u])
+            chosen_name = us_name.get(chosen_id, "")
+            source = "trusted"
+
+        if not chosen_id:
+            for listing in (f"XNAS:{ticker_u}", f"XNYS:{ticker_u}", f"ARCX:{ticker_u}"):
+                mapping = api.get_entity_mapping(
+                    [{"ticker": ticker_u, "listing": listing, "entity_type": "COMP"}]
+                )
+                if not mapping.matched:
+                    continue
+                hit = mapping.matched[0]
+                candidates = [hit, *(hit.candidates or [])]
+                for cand in candidates:
+                    cid = str(getattr(cand, "id", None) or getattr(cand, "rp_entity_id", "") or "")
+                    cname = str(getattr(cand, "name", "") or "")
+                    if cid and cid in us_ids:
+                        chosen_id, chosen_name, source = cid, cname or us_name[cid], f"listing:{listing}"
+                        break
+                if chosen_id:
+                    break
+                # keep first listing hit as fallback
+                chosen_id = str(hit.id)
+                chosen_name = str(hit.name or "")
+                source = f"listing_fallback:{listing}"
+                break
+
+        if not chosen_id:
+            mapping = api.get_entity_mapping([{"ticker": ticker_u, "entity_type": "COMP"}])
+            if mapping.matched:
+                hit = mapping.matched[0]
+                for cand in [hit, *(hit.candidates or [])]:
+                    cid = str(getattr(cand, "id", None) or getattr(cand, "rp_entity_id", "") or "")
+                    cname = str(getattr(cand, "name", "") or "")
+                    if cid and cid in us_ids:
+                        chosen_id, chosen_name, source = cid, cname or us_name[cid], "bare_us_sml"
+                        break
+                if not chosen_id:
+                    chosen_id = str(hit.id)
+                    chosen_name = str(hit.name or "")
+                    source = "bare_fallback"
+
+        if not chosen_id:
+            logger.warning("No Edge entity mapping for ticker=%s", ticker_u)
+            continue
+
+        rows.append(
+            {
+                "ticker": ticker_u,
+                "rp_entity_id": chosen_id,
+                "entity_name": chosen_name or us_name.get(chosen_id, ""),
+                "map_source": source,
+            }
+        )
+
+    return pd.DataFrame(rows)
+
+
+def build_filters(
+    entity_ids: list[str],
+    *,
+    min_entity_relevance: float | None,
+) -> dict[str, Any]:
+    clauses: list[dict[str, Any]] = [
+        {"rp_provider_id": {"$in": [PROVIDER_MRVR]}},
+        {"rp_entity_id": {"$in": entity_ids}},
+    ]
+    if min_entity_relevance is not None:
+        clauses.append({"entity_relevance": {"$gte": min_entity_relevance}})
+    return {"$and": clauses}
+
+
+def ensure_dataset(
+    api: RPApi,
+    dataset_id_path: Path | None,
+    *,
+    entity_ids: list[str] | None = None,
+    min_entity_relevance: float | None = None,
+    force_new: bool = False,
+) -> Dataset:
+    if (
+        not force_new
+        and dataset_id_path is not None
+        and dataset_id_path.exists()
+        and entity_ids is None
+    ):
+        dataset_id = dataset_id_path.read_text(encoding="utf-8").strip()
+        if dataset_id:
+            logger.info("Reusing Edge dataset %s", dataset_id)
+            return api.get_dataset(dataset_id=dataset_id)
+
+    filters: dict[str, Any]
+    if entity_ids:
+        filters = build_filters(entity_ids, min_entity_relevance=min_entity_relevance)
+        name = f"{DATASET_NAME}-universe"
+    else:
+        filters = {"rp_provider_id": {"$in": [PROVIDER_MRVR]}}
+        name = DATASET_NAME
+
+    ds = api.create_dataset(
+        Dataset(
+            name=name,
+            product="edge",
+            product_version="1.0",
+            frequency="granular",
+            fields=INTERNAL_FIELDS,
+            filters=filters,
+        )
+    )
+    logger.info("Created Edge dataset %s", ds.id)
+    if dataset_id_path is not None and entity_ids is None:
+        dataset_id_path.parent.mkdir(parents=True, exist_ok=True)
+        dataset_id_path.write_text(str(ds.id), encoding="utf-8")
+    return ds
+
+
+def records_to_frame(records: Any) -> pd.DataFrame:
+    rows: list[dict[str, Any]] = []
+    for record in records:
+        if hasattr(record, "as_dict"):
+            payload = record.as_dict()
+        elif isinstance(record, dict):
+            payload = record
+        else:
+            payload = {}
+            for key in INTERNAL_FIELDS:
+                if hasattr(record, key):
+                    payload[key] = getattr(record, key)
+                else:
+                    # Result objects often expose lower-case attrs
+                    payload[key] = getattr(record, key.lower(), None)
+        rows.append({k: payload.get(k) for k in INTERNAL_FIELDS})
+    if not rows:
+        return pd.DataFrame(columns=[*INTERNAL_FIELDS, "url"])
+    frame = pd.DataFrame(rows)
+    frame["url"] = None
+    return frame
+
+
+def query_window(
+    ds: Dataset,
+    *,
+    start: datetime,
+    end: datetime,
+    entity_ids: list[str],
+    min_entity_relevance: float | None,
+) -> pd.DataFrame:
+    filters = build_filters(entity_ids, min_entity_relevance=min_entity_relevance)
+    start_s = start.astimezone(UTC).strftime("%Y-%m-%d %H:%M:%S")
+    end_s = end.astimezone(UTC).strftime("%Y-%m-%d %H:%M:%S")
+    logger.info(
+        "Edge JSON %s → %s (%d entities, relevance=%s)",
+        start_s,
+        end_s,
+        len(entity_ids),
+        min_entity_relevance,
+    )
+    results = ds.json(
+        start_date=start_s,
+        end_date=end_s,
+        fields=INTERNAL_FIELDS,
+        filters=filters,
+    )
+    return records_to_frame(results)
+
+
+def fill_missing_urls(api: RPApi, df: pd.DataFrame) -> pd.DataFrame:
+    if df.empty:
+        return df
+    out = df.copy()
+    if "url" not in out.columns:
+        out["url"] = None
+    cache: dict[str, str] = {}
+    if "rp_document_id" not in out.columns:
+        return out
+    daily_limit_hit = False
+    for doc_id in out["rp_document_id"].dropna().astype(str).unique():
+        if not doc_id:
+            continue
+        if daily_limit_hit:
+            cache[doc_id] = ""
+            continue
+        try:
+            cache[doc_id] = str(api.get_document_url(doc_id) or "")
+        except Exception as exc:  # noqa: BLE001 — best-effort URL fill
+            msg = str(exc)
+            logger.warning("get_document_url failed for %s: %s", doc_id, exc)
+            cache[doc_id] = ""
+            if "Requests-per-day" in msg or "429" in msg:
+                logger.error("Document URL daily limit hit — skipping remaining URL lookups")
+                daily_limit_hit = True
+        time.sleep(0.02)
+    out["url"] = out["rp_document_id"].astype(str).map(cache)
+    return out
+
+
+def unique_stories(df: pd.DataFrame) -> pd.DataFrame:
+    if df.empty:
+        return pd.DataFrame(columns=list(OUTPUT_COLUMNS))
+    work = df.copy()
+    if "rp_document_id" in work.columns and "rp_entity_id" in work.columns:
+        work = work.drop_duplicates(subset=["rp_document_id", "rp_entity_id"], keep="first")
+    else:
+        work = work.drop_duplicates(subset=["title", "entity_name", "timestamp_utc"], keep="first")
+    out = pd.DataFrame(
+        {
+            "timestamp_utc": work["timestamp_utc"],
+            "company_name": work["entity_name"],
+            "title": work["title"],
+            "source_name": work["source_name"],
+            "url": work.get("url"),
+            "entity_relevance": work.get("entity_relevance"),
+            "entity_sentiment": work.get("entity_sentiment"),
+            "title_similarity_days": work.get("title_similarity_days"),
+            "rp_document_id": work.get("rp_document_id"),
+        }
+    )
+    return out.reset_index(drop=True)
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, default=str), encoding="utf-8")
+
+
+def normalize_title(text: str) -> str:
+    cleaned = text.lower()
+    cleaned = re.sub(r"\s*\|\s*.*$", "", cleaned)  # drop trailing "| Source"
+    cleaned = re.sub(r"[^a-z0-9\s]", " ", cleaned)
+    cleaned = re.sub(r"\s+", " ", cleaned).strip()
+    return cleaned
+
+
+def title_similarity(a: str, b: str) -> float:
+    na, nb = normalize_title(a), normalize_title(b)
+    if not na or not nb:
+        return 0.0
+    if na == nb:
+        return 1.0
+    if na in nb or nb in na:
+        return 0.95
+    ta, tb = set(na.split()), set(nb.split())
+    if not ta or not tb:
+        return 0.0
+    return len(ta & tb) / len(ta | tb)
+
+
+def run_pull(
+    *,
+    output_dir: Path,
+    min_entity_relevance: float | None,
+    skip_urls: bool = False,
+    universe: Path | None = None,
+    tickers: str | None = None,
+    entity_ids: str | None = None,
+    missed_csv: Path | None = None,
+    limit_entities: int = 0,
+    start: str | None = None,
+    end: str | None = None,
+    window_end: str | None = None,
+    window_minutes: int = 15,
+    force_new_dataset: bool = True,
+) -> dict[str, Any]:
+    """Pull MRVR stories for a universe over a time window."""
+    output_dir.mkdir(parents=True, exist_ok=True)
+    api = make_api()
+    mapping = resolve_entity_mapping(
+        api,
+        output_dir=output_dir,
+        universe=universe,
+        tickers=tickers,
+        entity_ids=entity_ids,
+        missed_csv=missed_csv,
+        limit_entities=limit_entities,
+        reuse_mapping=True,
+    )
+    entity_ids_list = sorted(set(mapping["rp_entity_id"].astype(str).tolist()))
+    if not entity_ids_list:
+        raise SystemExit("No entities resolved for universe")
+
+    ds = ensure_dataset(
+        api,
+        output_dir / "dataset_id.txt",
+        force_new=force_new_dataset,
+    )
+    start_dt, end_dt = resolve_time_window(
+        start=start,
+        end=end,
+        window_end=window_end,
+        window_minutes=window_minutes,
+    )
+    raw = query_window(
+        ds,
+        start=start_dt,
+        end=end_dt,
+        entity_ids=entity_ids_list,
+        min_entity_relevance=min_entity_relevance,
+    )
+    if not skip_urls:
+        raw = fill_missing_urls(api, raw)
+    elif "url" not in raw.columns:
+        raw["url"] = None
+    raw.to_csv(output_dir / "raw_records.csv", index=False)
+    stories = unique_stories(raw)
+    stories.to_csv(output_dir / "stories_unique.csv", index=False)
+
+    summary = {
+        "mode": "pull",
+        "window_start": start_dt.isoformat(),
+        "window_end": end_dt.isoformat(),
+        "mapped_entities": len(entity_ids_list),
+        "raw_rows": int(len(raw)),
+        "unique_stories": int(len(stories)),
+        "url_non_null": int(stories["url"].fillna("").astype(str).str.len().gt(0).sum())
+        if not stories.empty
+        else 0,
+        "min_entity_relevance": min_entity_relevance,
+        "provider": PROVIDER_MRVR,
+        "dataset_id": ds.id,
+        "skip_urls": skip_urls,
+        "fields": list(INTERNAL_FIELDS),
+    }
+    write_json(output_dir / "run_summary.json", summary)
+    logger.info(
+        "pull done — raw=%d unique=%d url_filled=%d window=%s→%s",
+        summary["raw_rows"],
+        summary["unique_stories"],
+        summary["url_non_null"],
+        start_dt.isoformat(),
+        end_dt.isoformat(),
+    )
+    return summary
+
+
+def run_last15(
+    *,
+    missed_csv: Path,
+    output_dir: Path,
+    min_entity_relevance: float | None,
+    window_minutes: int,
+    skip_urls: bool = False,
+    universe: Path | None = None,
+    tickers: str | None = None,
+    entity_ids: str | None = None,
+    limit_entities: int = 0,
+    start: str | None = None,
+    end: str | None = None,
+    window_end: str | None = None,
+) -> dict[str, Any]:
+    """Alias for ``pull`` (backward compatible name)."""
+    return run_pull(
+        output_dir=output_dir,
+        min_entity_relevance=min_entity_relevance,
+        skip_urls=skip_urls,
+        universe=universe,
+        tickers=tickers,
+        entity_ids=entity_ids,
+        missed_csv=missed_csv if missed_csv.exists() else None,
+        limit_entities=limit_entities,
+        start=start,
+        end=end,
+        window_end=window_end,
+        window_minutes=window_minutes,
+        force_new_dataset=True,
+    )
+
+def query_range_via_datafile(
+    ds: Dataset,
+    *,
+    start: datetime,
+    end: datetime,
+    output_csv: Path,
+) -> pd.DataFrame:
+    """Async datafile pull for ranges that exceed the JSON 10k cap."""
+    start_s = start.astimezone(UTC).strftime("%Y-%m-%d %H:%M:%S")
+    end_s = end.astimezone(UTC).strftime("%Y-%m-%d %H:%M:%S")
+    logger.info("Edge datafile %s → %s (dataset=%s)", start_s, end_s, ds.id)
+    job = ds.request_datafile(
+        start_date=start_s,
+        end_date=end_s,
+        output_format="csv",
+        compressed=False,
+        fields=INTERNAL_FIELDS,
+        allow_empty=True,
+    )
+    if job is None:
+        logger.warning("Datafile empty for %s → %s", start_s, end_s)
+        return pd.DataFrame(columns=[*INTERNAL_FIELDS, "url"])
+    output_csv.parent.mkdir(parents=True, exist_ok=True)
+    job.save_to_file(str(output_csv))
+    frame = pd.read_csv(output_csv)
+    # Normalize column names to snake_case expected internally
+    frame.columns = [str(c).strip().lower() for c in frame.columns]
+    for col in INTERNAL_FIELDS:
+        if col not in frame.columns:
+            frame[col] = None
+    frame["url"] = None
+    return frame[INTERNAL_FIELDS + ["url"]]
+
+
+def query_range_chunked(
+    ds: Dataset,
+    *,
+    start: datetime,
+    end: datetime,
+    entity_ids: list[str],
+    min_entity_relevance: float | None,
+    chunk_hours: int = 6,
+) -> pd.DataFrame:
+    """JSON pull with auto-shrink on 10k overflow."""
+    frames: list[pd.DataFrame] = []
+    cursor = start
+    while cursor < end:
+        chunk_end = min(cursor + timedelta(hours=chunk_hours), end)
+        try:
+            frame = query_window(
+                ds,
+                start=cursor,
+                end=chunk_end,
+                entity_ids=entity_ids,
+                min_entity_relevance=min_entity_relevance,
+            )
+            frames.append(frame)
+        except Exception as exc:  # noqa: BLE001
+            msg = str(exc)
+            if "exceeds 10000" in msg and chunk_hours > 1:
+                logger.warning(
+                    "Chunk %s→%s exceeded 10k; splitting to %dh",
+                    cursor,
+                    chunk_end,
+                    max(1, chunk_hours // 2),
+                )
+                mid = cursor + (chunk_end - cursor) / 2
+                left = query_range_chunked(
+                    ds,
+                    start=cursor,
+                    end=mid,
+                    entity_ids=entity_ids,
+                    min_entity_relevance=min_entity_relevance,
+                    chunk_hours=max(1, chunk_hours // 2),
+                )
+                right = query_range_chunked(
+                    ds,
+                    start=mid,
+                    end=chunk_end,
+                    entity_ids=entity_ids,
+                    min_entity_relevance=min_entity_relevance,
+                    chunk_hours=max(1, chunk_hours // 2),
+                )
+                frames.extend([left, right])
+            else:
+                logger.error("Chunk failed %s→%s: %s", cursor, chunk_end, exc)
+        cursor = chunk_end
+        time.sleep(0.15)
+    if not frames:
+        return pd.DataFrame(columns=[*INTERNAL_FIELDS, "url"])
+    return pd.concat(frames, ignore_index=True)
+
+
+def run_recover(
+    *,
+    missed_csv: Path,
+    output_dir: Path,
+    min_entity_relevance: float | None,
+    match_threshold: float,
+    skip_urls: bool = False,
+) -> dict[str, Any]:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    api = make_api()
+    missed = read_missed_stories(missed_csv)
+    tickers = unique_tickers(missed)
+    mapping = map_tickers(api, tickers)
+    mapping.to_csv(output_dir / "entity_mapping.csv", index=False)
+    entity_ids = sorted(set(mapping["rp_entity_id"].astype(str).tolist()))
+    ticker_to_entity = dict(zip(mapping["ticker"], mapping["rp_entity_id"], strict=True))
+
+    dated = missed.dropna(subset=["Pub Date"])
+    if dated.empty:
+        raise SystemExit("MissedStories Pub Date column is empty / unparseable")
+
+    start = dated["Pub Date"].min().to_pydatetime().replace(tzinfo=UTC) - timedelta(hours=6)
+    end = dated["Pub Date"].max().to_pydatetime().replace(tzinfo=UTC) + timedelta(hours=6)
+
+    # Bake universe into dataset so datafile respects entity filter (JSON 10k too small)
+    ds = ensure_dataset(
+        api,
+        None,
+        entity_ids=entity_ids,
+        min_entity_relevance=min_entity_relevance,
+        force_new=True,
+    )
+    (output_dir / "dataset_id.txt").write_text(str(ds.id), encoding="utf-8")
+
+    raw = query_range_via_datafile(
+        ds,
+        start=start,
+        end=end,
+        output_csv=output_dir / "datafile_raw.csv",
+    )
+    if "url" not in raw.columns:
+        raw["url"] = None
+    raw.to_csv(output_dir / "raw_records.csv", index=False)
+    stories = unique_stories(raw)
+    stories.to_csv(output_dir / "stories_unique.csv", index=False)
+
+    entity_to_ticker = {v: k for k, v in ticker_to_entity.items()}
+    edge = raw.copy()
+    if "rp_entity_id" in edge.columns:
+        edge["ticker"] = edge["rp_entity_id"].astype(str).map(entity_to_ticker)
+    else:
+        edge["ticker"] = None
+
+    by_ticker: dict[str, pd.DataFrame] = {
+        str(t): g for t, g in edge.groupby("ticker") if pd.notna(t)
+    }
+
+    match_rows: list[dict[str, Any]] = []
+    matched_doc_ids: set[str] = set()
+    for _, story in missed.iterrows():
+        ticker = str(story["Ticker"]).upper()
+        headline = str(story["Headline"])
+        candidates = by_ticker.get(ticker, pd.DataFrame())
+        best_score = 0.0
+        best_title = ""
+        best_doc = ""
+        best_ts = ""
+        best_source = ""
+        for _, cand in candidates.iterrows():
+            score = title_similarity(headline, str(cand.get("title") or ""))
+            if score > best_score:
+                best_score = score
+                best_title = str(cand.get("title") or "")
+                best_doc = str(cand.get("rp_document_id") or "")
+                best_ts = str(cand.get("timestamp_utc") or "")
+                best_source = str(cand.get("source_name") or "")
+        matched = best_score >= match_threshold
+        if matched and best_doc:
+            matched_doc_ids.add(best_doc)
+        match_rows.append(
+            {
+                "ticker": ticker,
+                "missed_headline": headline,
+                "publisher": story.get("Publisher"),
+                "pub_date": story.get("Pub Date"),
+                "matched": matched,
+                "match_score": round(best_score, 3),
+                "edge_title": best_title if matched else "",
+                "edge_source": best_source if matched else "",
+                "edge_timestamp_utc": best_ts if matched else "",
+                "rp_document_id": best_doc if matched else "",
+                "edge_url": "",
+            }
+        )
+
+    url_cache: dict[str, str] = {}
+    if not skip_urls:
+        daily_limit_hit = False
+        for doc_id in sorted(matched_doc_ids):
+            if daily_limit_hit:
+                url_cache[doc_id] = ""
+                continue
+            try:
+                url_cache[doc_id] = str(api.get_document_url(doc_id) or "")
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("get_document_url failed for %s: %s", doc_id, exc)
+                url_cache[doc_id] = ""
+                if "Requests-per-day" in str(exc):
+                    daily_limit_hit = True
+            time.sleep(0.02)
+    for row in match_rows:
+        doc_id = str(row.get("rp_document_id") or "")
+        if doc_id:
+            row["edge_url"] = url_cache.get(doc_id, "")
+
+    matches = pd.DataFrame(match_rows)
+    matches.to_csv(output_dir / "missed_match_report.csv", index=False)
+    matched_n = int(matches["matched"].sum()) if not matches.empty else 0
+    summary = {
+        "mode": "recover",
+        "query_start": start.isoformat(),
+        "query_end": end.isoformat(),
+        "missed_stories": int(len(missed)),
+        "missed_with_pub_date": int(len(dated)),
+        "matched": matched_n,
+        "match_rate": round(matched_n / len(missed), 4) if len(missed) else 0.0,
+        "match_threshold": match_threshold,
+        "raw_rows": int(len(raw)),
+        "unique_stories": int(len(stories)),
+        "mapped_entities": len(entity_ids),
+        "min_entity_relevance": min_entity_relevance,
+        "provider": PROVIDER_MRVR,
+        "dataset_id": ds.id,
+        "note": "MRVR-only web content; premium publishers in MissedStories may be out of scope",
+    }
+    write_json(output_dir / "run_summary.json", summary)
+    logger.info(
+        "recover done — matched %d / %d (%.1f%%)",
+        matched_n,
+        len(missed),
+        100.0 * summary["match_rate"],
+    )
+    return summary
+
+
+def run_feed(
+    *,
+    output_dir: Path,
+    min_entity_relevance: float | None,
+    interval_minutes: int,
+    max_buckets: int,
+    skip_urls: bool = False,
+    universe: Path | None = None,
+    tickers: str | None = None,
+    entity_ids: str | None = None,
+    missed_csv: Path | None = None,
+    limit_entities: int = 0,
+) -> None:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    api = make_api()
+    mapping = resolve_entity_mapping(
+        api,
+        output_dir=output_dir,
+        universe=universe,
+        tickers=tickers,
+        entity_ids=entity_ids,
+        missed_csv=missed_csv,
+        limit_entities=limit_entities,
+        reuse_mapping=True,
+    )
+    entity_ids_list = sorted(set(mapping["rp_entity_id"].astype(str).tolist()))
+    ds = ensure_dataset(api, output_dir / "dataset_id.txt", force_new=True)
+
+    buckets_done = 0
+    while max_buckets <= 0 or buckets_done < max_buckets:
+        end = datetime.now(UTC).replace(microsecond=0)
+        start = end - timedelta(minutes=interval_minutes)
+        stamp = end.strftime("%Y%m%d_%H%M%S")
+        bucket_dir = output_dir / f"bucket_{stamp}"
+        bucket_dir.mkdir(parents=True, exist_ok=True)
+        raw = query_window(
+            ds,
+            start=start,
+            end=end,
+            entity_ids=entity_ids_list,
+            min_entity_relevance=min_entity_relevance,
+        )
+        if not skip_urls:
+            raw = fill_missing_urls(api, raw)
+        elif "url" not in raw.columns:
+            raw["url"] = None
+        stories = unique_stories(raw)
+        stories.to_csv(bucket_dir / "stories_unique.csv", index=False)
+        write_json(
+            bucket_dir / "run_summary.json",
+            {
+                "window_start": start.isoformat(),
+                "window_end": end.isoformat(),
+                "raw_rows": int(len(raw)),
+                "unique_stories": int(len(stories)),
+                "dataset_id": ds.id,
+                "skip_urls": skip_urls,
+            },
+        )
+        buckets_done += 1
+        logger.info(
+            "feed bucket %s — unique=%d (bucket %d)",
+            stamp,
+            len(stories),
+            buckets_done,
+        )
+        if max_buckets > 0 and buckets_done >= max_buckets:
+            break
+        sleep_s = interval_minutes * 60
+        logger.info("Sleeping %d seconds until next bucket", sleep_s)
+        time.sleep(sleep_s)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "mode",
+        choices=["pull", "last15", "recover", "feed"],
+        help="pull (or last15 alias) | recover MissedStories | continuous feed",
+    )
+    parser.add_argument(
+        "--universe",
+        type=Path,
+        default=None,
+        help="Universe CSV with RP_ENTITY_ID [, COMPANY_NAME] [, ticker] (e.g. us_sml.csv)",
+    )
+    parser.add_argument(
+        "--tickers",
+        type=str,
+        default=None,
+        help="Comma-separated tickers to map via Edge (e.g. AAPL,MSFT,NVDA)",
+    )
+    parser.add_argument(
+        "--entity-ids",
+        type=str,
+        default=None,
+        help="Comma-separated RP entity ids (skip ticker mapping)",
+    )
+    parser.add_argument(
+        "--missed-csv",
+        type=Path,
+        default=Path("MissedStories.csv"),
+        help="MissedStories CSV (Ticker column) for recover, or fallback universe",
+    )
+    parser.add_argument(
+        "--limit-entities",
+        type=int,
+        default=0,
+        help="Optional cap on universe size after load (0 = all)",
+    )
+    parser.add_argument("--output-dir", type=Path, default=None)
+    parser.add_argument(
+        "--min-entity-relevance",
+        type=float,
+        default=None,
+        help="Optional entity_relevance floor (e.g. 90)",
+    )
+    parser.add_argument(
+        "--start",
+        type=str,
+        default=None,
+        help="Window start UTC ISO (use with --end), e.g. 2026-07-28T12:00:00Z",
+    )
+    parser.add_argument(
+        "--end",
+        type=str,
+        default=None,
+        help="Window end UTC ISO (use with --start)",
+    )
+    parser.add_argument(
+        "--window-end",
+        type=str,
+        default=None,
+        help="Window end UTC ISO; default now. Used with --window-minutes",
+    )
+    parser.add_argument(
+        "--window-minutes",
+        type=int,
+        default=15,
+        help="Minutes before --window-end (default 15). Ignored if --start/--end set",
+    )
+    parser.add_argument("--match-threshold", type=float, default=0.72)
+    parser.add_argument(
+        "--interval-minutes",
+        type=int,
+        default=15,
+        help="Feed mode: bucket length in minutes",
+    )
+    parser.add_argument(
+        "--max-buckets",
+        type=int,
+        default=1,
+        help="For feed mode: number of buckets then exit (0 = forever)",
+    )
+    parser.add_argument(
+        "--skip-urls",
+        action="store_true",
+        help="Do not call document URL endpoint (saves quota; leave url empty)",
+    )
+    parser.add_argument("-v", "--verbose", action="store_true")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+
+    if args.output_dir is None:
+        stamp = datetime.now(UTC).strftime("%Y%m%d_%H%M%S")
+        mode_name = "pull" if args.mode == "last15" else args.mode
+        args.output_dir = Path("runs") / f"edge_{mode_name}_{stamp}"
+
+    if args.mode in {"pull", "last15"}:
+        run_pull(
+            output_dir=args.output_dir,
+            min_entity_relevance=args.min_entity_relevance,
+            skip_urls=args.skip_urls,
+            universe=args.universe,
+            tickers=args.tickers,
+            entity_ids=args.entity_ids,
+            missed_csv=args.missed_csv if args.missed_csv.exists() else None,
+            limit_entities=args.limit_entities,
+            start=args.start,
+            end=args.end,
+            window_end=args.window_end,
+            window_minutes=args.window_minutes,
+        )
+    elif args.mode == "recover":
+        run_recover(
+            missed_csv=args.missed_csv,
+            output_dir=args.output_dir,
+            min_entity_relevance=args.min_entity_relevance,
+            match_threshold=args.match_threshold,
+            skip_urls=args.skip_urls,
+        )
+    else:
+        run_feed(
+            output_dir=args.output_dir,
+            min_entity_relevance=args.min_entity_relevance,
+            interval_minutes=args.interval_minutes,
+            max_buckets=args.max_buckets,
+            skip_urls=args.skip_urls,
+            universe=args.universe,
+            tickers=args.tickers,
+            entity_ids=args.entity_ids,
+            missed_csv=args.missed_csv if args.missed_csv.exists() else None,
+            limit_entities=args.limit_entities,
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Add RavenPack Edge MRVR runner (`scripts/edge_mrvr_stories.py`) with CLI controls for universe (`--universe` / `--tickers` / `--entity-ids`) and time windows (`--start`/`--end` or `--window-minutes`/`--window-end`).
- Resolve article URLs via `rp_document_id`, emit relevance / sentiment / novelty fields, and keep optional offline rematch helper.
- Refresh README: Edge MRVR first, plus a complete reference section for the existing `client-news-monitor` Bigdata CLI (no run artifacts included).

## Test plan
- [x] `uv run python -m pytest tests/ -v` (23 passed)
- [x] Live Edge pull: `--tickers AAPL,MSFT --window-minutes 15` (with and without URL fill)
- [x] Live Bigdata: `client-news-monitor --skip-mas --limit-entities 20`
- [ ] Confirm `runs/` and `*.egg-info/` are not in the PR diff


Made with [Cursor](https://cursor.com)