### PR TITLE
Clarify Edge pull vs live stream wording

### DIFF
--- a/News_Monitor_MAS/README.md
+++ b/News_Monitor_MAS/README.md
@@ -45,7 +45,7 @@ uv run python scripts/edge_mrvr_stories.py pull \
 
 ## Real-time streaming
 
-Historical `pull` uses the analytics JSON API. Edge also supports a **live NDJSON stream** on a different host:
+`pull` / `feed` use the analytics JSON API (request/response over a time window — including a rolling last-N-minutes). Edge also supports a **live NDJSON stream** on a different host:
 
 ```text
 GET https://feed-edge.ravenpack.com/1.0/json/{dataset_id}?keep_alive=t
@@ -53,7 +53,7 @@ GET https://feed-edge.ravenpack.com/1.0/json/{dataset_id}?keep_alive=t
 
 - Response is **HTTP 200** and stays open; records are JSON objects separated by `\n`.
 - ``keep_alive=t`` emits a bare newline after ~30s of silence (reset the connection if silent >60s).
-- Streaming uses the **dataset’s baked-in filters only**. Create the dataset with `rp_provider_id=MRVR` and your `rp_entity_id` universe (the sample script does this). Filters passed only on historical query calls are **not** applied to the feed.
+- Streaming uses the **dataset’s baked-in filters only**. Create the dataset with `rp_provider_id=MRVR` and your `rp_entity_id` universe (the sample script does this). Filters passed only on analytics query calls are **not** applied to the feed.
 
 ### Sample script
 

--- a/News_Monitor_MAS/scripts/edge_mrvr_stream.py
+++ b/News_Monitor_MAS/scripts/edge_mrvr_stream.py
@@ -11,7 +11,7 @@ a healthy connection (reset if silent for >60s).
 
 Important: streaming applies only the **dataset definition filters**. Entity
 universe and ``rp_provider_id=MRVR`` must be baked into the dataset (this script
-creates that dataset). Ad-hoc filters used by historical ``pull`` are not sent
+creates that dataset). Ad-hoc filters used by analytics ``pull`` are not sent
 on the stream.
 
 Examples::


### PR DESCRIPTION
## Summary
- Replace misleading “Historical pull” language: `pull`/`feed` are windowed analytics queries (including last-N-minutes), contrasted with the live `feed-edge` stream

Follow-up wording fix after #121.

## Test plan
- [ ] README streaming section reads clearly on GitHub


Made with [Cursor](https://cursor.com)